### PR TITLE
fix: Resolve pg_dump version mismatch, CORS preflight, and dump persistence

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ node_modules
 .env.local
 .env.development
 
+# Dump files
+Backend-Dumps/
+Backend-Logs/
+
 # Logs
 logs
 *.log
@@ -19,3 +23,5 @@ Backend/aspnet-core/.claude/settings.local.json
 .claude/settings.local.json
 .claude/settings.local.json
 .claude/settings.local.json
+
+

--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/DatabaseConnectionService/Jobs/DatabaseDumpArgs.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/DatabaseConnectionService/Jobs/DatabaseDumpArgs.cs
@@ -3,6 +3,7 @@ using System;
 namespace sql_optimizer.Services.DatabaseConnectionService.Jobs;
 
 /// <summary>Arguments passed to the database dump background job.</summary>
+/// 
 public class DatabaseDumpArgs
 {
     public Guid ConnectionId { get; set; }

--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/DatabaseConnectionService/Jobs/DatabaseDumpJob.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/DatabaseConnectionService/Jobs/DatabaseDumpJob.cs
@@ -14,61 +14,61 @@ namespace sql_optimizer.Services.DatabaseConnectionService.Jobs;
 /// Background job that runs pg_dump against the saved connection and
 /// stores the resulting SQL file on the server.
 /// </summary>
+[UnitOfWork]
 public class DatabaseDumpJob
     : AsyncBackgroundJob<DatabaseDumpArgs>, ITransientDependency
 {
     private readonly IRepository<DatabaseConnection, Guid> _repository;
-    private readonly IUnitOfWorkManager _unitOfWorkManager;
 
-    public DatabaseDumpJob(
-        IRepository<DatabaseConnection, Guid> repository,
-        IUnitOfWorkManager unitOfWorkManager)
+    public DatabaseDumpJob(IRepository<DatabaseConnection, Guid> repository)
     {
         _repository = repository;
-        _unitOfWorkManager = unitOfWorkManager;
     }
 
     public override async Task ExecuteAsync(DatabaseDumpArgs args)
     {
         Logger.Info($"[DatabaseDumpJob] Starting dump for connection {args.ConnectionId}");
 
-        DatabaseConnection connection;
+        var connection = await _repository.GetAsync(args.ConnectionId);
+        connection.DumpStatus = DumpStatus.InProgress;
+        await _repository.UpdateAsync(connection);
+        await CurrentUnitOfWork.SaveChangesAsync();
 
-        using (var uow = _unitOfWorkManager.Begin())
-        {
-            connection = await _repository.GetAsync(args.ConnectionId);
-            connection.DumpStatus = DumpStatus.InProgress;
-            await _repository.UpdateAsync(connection);
-            await uow.CompleteAsync();
-        }
-
-        string dumpFilePath = null;
+        var dumpFilePath = GetDumpFilePath(args.ConnectionId);
         string errorMessage = null;
         var succeeded = false;
 
         try
         {
-            dumpFilePath = GetDumpFilePath(args.ConnectionId);
             Directory.CreateDirectory(Path.GetDirectoryName(dumpFilePath)!);
+            var (exitCode, stderr) = await RunPgDumpAsync(connection, dumpFilePath);
 
-            succeeded = await RunPgDumpAsync(connection, dumpFilePath);
+            if (exitCode != 0)
+            {
+                errorMessage = $"pg_dump exited with code {exitCode}. {stderr}".Trim();
+                Logger.Warn($"[DatabaseDumpJob] {errorMessage}");
+            }
+            else if (!File.Exists(dumpFilePath))
+            {
+                errorMessage = "pg_dump exited successfully but no dump file was created.";
+                Logger.Warn($"[DatabaseDumpJob] {errorMessage}");
+            }
+            else
+            {
+                succeeded = true;
+            }
         }
         catch (Exception ex)
         {
-            Logger.Error($"[DatabaseDumpJob] Unexpected error for connection {args.ConnectionId}: {ex.Message}", ex);
             errorMessage = ex.Message;
+            Logger.Error($"[DatabaseDumpJob] Unexpected error for connection {args.ConnectionId}: {ex.Message}", ex);
         }
 
-        using (var uow = _unitOfWorkManager.Begin())
-        {
-            var entity = await _repository.GetAsync(args.ConnectionId);
-            entity.DumpStatus = succeeded ? DumpStatus.Completed : DumpStatus.Failed;
-            entity.LastDumpTime = DateTime.UtcNow;
-            entity.DumpFilePath = succeeded ? dumpFilePath : null;
-            entity.DumpErrorMessage = succeeded ? null : errorMessage;
-            await _repository.UpdateAsync(entity);
-            await uow.CompleteAsync();
-        }
+        connection.DumpStatus = succeeded ? DumpStatus.Completed : DumpStatus.Failed;
+        connection.LastDumpTime = DateTime.UtcNow;
+        connection.DumpFilePath = succeeded ? dumpFilePath : null;
+        connection.DumpErrorMessage = succeeded ? null : errorMessage;
+        await _repository.UpdateAsync(connection);
 
         if (succeeded)
             Logger.Info($"[DatabaseDumpJob] Dump completed for connection {args.ConnectionId}. File: {dumpFilePath}");
@@ -76,39 +76,33 @@ public class DatabaseDumpJob
             Logger.Warn($"[DatabaseDumpJob] Dump failed for connection {args.ConnectionId}. Error: {errorMessage}");
     }
 
-    private async Task<bool> RunPgDumpAsync(DatabaseConnection connection, string outputPath)
+    private static async Task<(int exitCode, string stderr)> RunPgDumpAsync(
+        DatabaseConnection connection, string outputPath)
     {
         var database = string.IsNullOrWhiteSpace(connection.DatabaseName) ? "postgres" : connection.DatabaseName;
         var connString = $"postgresql://{connection.DbUser}:{Uri.EscapeDataString(connection.DbPassword)}@{connection.DbHost}:{connection.DbPort}/{database}";
 
-        Logger.Debug($"[DatabaseDumpJob] Running pg_dump for host={connection.DbHost}, db={database}");
-
         var psi = new ProcessStartInfo
         {
             FileName = "pg_dump",
-            Arguments = $"--no-password --format=plain --file={outputPath} {connString}",
             RedirectStandardError = true,
             UseShellExecute = false,
             CreateNoWindow = true
         };
 
-        using var process = Process.Start(psi);
-        if (process == null)
-        {
-            Logger.Error("[DatabaseDumpJob] Failed to start pg_dump process.");
-            return false;
-        }
+        // Pass each argument separately to avoid shell-parsing issues with special characters
+        psi.ArgumentList.Add("--no-password");
+        psi.ArgumentList.Add("--format=plain");
+        psi.ArgumentList.Add($"--file={outputPath}");
+        psi.ArgumentList.Add(connString);
+
+        using var process = Process.Start(psi)
+            ?? throw new InvalidOperationException("Failed to start pg_dump process.");
 
         var stderr = await process.StandardError.ReadToEndAsync();
         await process.WaitForExitAsync();
 
-        if (process.ExitCode != 0)
-        {
-            Logger.Warn($"[DatabaseDumpJob] pg_dump exited with code {process.ExitCode}. stderr: {stderr}");
-            return false;
-        }
-
-        return true;
+        return (process.ExitCode, stderr);
     }
 
     private static string GetDumpFilePath(Guid connectionId)

--- a/Backend/aspnet-core/src/sql_optimizer.Web.Host/Dockerfile
+++ b/Backend/aspnet-core/src/sql_optimizer.Web.Host/Dockerfile
@@ -20,6 +20,13 @@ WORKDIR "/src/src/sql_optimizer.Web.Host"
 RUN dotnet publish -c Release -o /publish --no-restore
 
 FROM mcr.microsoft.com/dotnet/aspnet:9.0
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends curl ca-certificates gnupg \
+    && curl -fsSL https://www.postgresql.org/media/keys/ACCC4CF8.asc | gpg --dearmor -o /usr/share/keyrings/postgresql.gpg \
+    && echo "deb [signed-by=/usr/share/keyrings/postgresql.gpg] https://apt.postgresql.org/pub/repos/apt bookworm-pgdg main" > /etc/apt/sources.list.d/pgdg.list \
+    && apt-get update \
+    && apt-get install -y --no-install-recommends postgresql-client-17 \
+    && rm -rf /var/lib/apt/lists/*
 EXPOSE 80
 WORKDIR /app
 COPY --from=build /publish .

--- a/Backend/aspnet-core/src/sql_optimizer.Web.Host/Startup/Startup.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Web.Host/Startup/Startup.cs
@@ -83,9 +83,10 @@ namespace sql_optimizer.Web.Host.Startup
 
         public void Configure(IApplicationBuilder app, IWebHostEnvironment env, ILoggerFactory loggerFactory)
         {
+            app.UseCors(_defaultCorsPolicyName); // Enable CORS! Must be before UseAbp/UseRouting.
+
             app.UseAbp(options => { options.UseAbpRequestLocalization = false; }); // Initializes ABP framework.
 
-            app.UseCors(_defaultCorsPolicyName); // Enable CORS!
 
             app.UseStaticFiles();
 

--- a/Backend/aspnet-core/src/sql_optimizer.Web.Host/appsettings.json
+++ b/Backend/aspnet-core/src/sql_optimizer.Web.Host/appsettings.json
@@ -5,7 +5,7 @@
   "App": {
     "ServerRootAddress": "https://localhost:44311/",
     "ClientRootAddress": "http://localhost:4200/",
-    "CorsOrigins": "http://localhost:4200,http://localhost:8080,http://localhost:8081,http://localhost:3000"
+    "CorsOrigins": "http://localhost:4200,http://localhost:8080,http://localhost:8081,http://localhost:3000,http://localhost:3001"
   },
   "Authentication": {
     "JwtBearer": {

--- a/docker-compose.local.yml
+++ b/docker-compose.local.yml
@@ -1,0 +1,30 @@
+services:
+  backend:
+    build:
+      context: Backend/aspnet-core
+      dockerfile: src/sql_optimizer.Web.Host/Dockerfile
+    ports:
+      - "44311:80"
+    environment:
+      ASPNETCORE_ENVIRONMENT: Development
+      Kestrel__Endpoints__Http__Url: "http://+:80"
+      ConnectionStrings__Default: ${DB_CONNECTION_STRING}
+      Authentication__JwtBearer__IsEnabled: "true"
+      Authentication__JwtBearer__SecurityKey: ${JWT_SECURITY_KEY}
+      Authentication__JwtBearer__Issuer: "sql_optimizer"
+      Authentication__JwtBearer__Audience: "sql_optimizer"
+      App__ServerRootAddress: "http://localhost:44311/"
+      App__ClientRootAddress: "http://localhost:3000/"
+      App__CorsOrigins: "http://localhost:3000,http://localhost:3001"
+    volumes:
+      - ./Backend-Logs:/app/App_Data/Logs
+      - ./Backend-Dumps:/app/App_Data/Dumps
+    restart: unless-stopped
+
+  frontend:
+    build:
+      context: Frontend
+      dockerfile: Dockerfile
+    ports:
+      - "3000:3000"
+    restart: unless-stopped


### PR DESCRIPTION
## Summary

- Install `postgresql-client-17` via the official PostgreSQL apt repo in the Dockerfile — fixes `pg_dump` version mismatch against Supabase (PostgreSQL 17)
- Move `app.UseCors` before `app.UseAbp` in `Startup.cs` — fixes CORS preflight (OPTIONS) returning 405
- Rewrite `DatabaseDumpJob` to use ABP's ambient UoW instead of nested manual UoWs — fixes `DumpFilePath` not being persisted after a successful dump
- Switch `pg_dump` to use `ArgumentList` instead of `Arguments` string — avoids shell-parsing issues with special characters in passwords
- Add `File.Exists` check after `pg_dump` completes — catches cases where the process exits 0 but writes to stdout instead of the file
- Add `docker-compose.local.yml` for local development
- Add `Backend-Dumps/` and `Backend-Logs/` to `.gitignore` — prevents dump files from being committed
