### PR TITLE
feat: Schema panel, connection editing, and AI analysis fixes

### DIFF
--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/DatabaseConnectionService/DTO/UpdateConnectionSettingsInput.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/DatabaseConnectionService/DTO/UpdateConnectionSettingsInput.cs
@@ -1,0 +1,19 @@
+using System;
+using System.ComponentModel.DataAnnotations;
+
+namespace sql_optimizer.Services.DatabaseConnectionService.DTO;
+
+/// <summary>
+/// Input for updating the editable settings of an existing connection —
+/// currently DatabaseName and SchemaOnly.
+/// </summary>
+public class UpdateConnectionSettingsInput
+{
+    [Required]
+    public Guid Id { get; set; }
+
+    [MaxLength(100)]
+    public string DatabaseName { get; set; }
+
+    public bool SchemaOnly { get; set; }
+}

--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/DatabaseConnectionService/DatabaseConnectionAppService.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/DatabaseConnectionService/DatabaseConnectionAppService.cs
@@ -97,6 +97,24 @@ public class DatabaseConnectionAppService
     }
 
     /// <summary>
+    /// Updates DatabaseName and SchemaOnly on an existing connection, then re-triggers the dump.
+    /// </summary>
+    public async Task UpdateSettingsAsync(UpdateConnectionSettingsInput input)
+    {
+        var entity = await Repository.GetAsync(input.Id);
+        entity.DatabaseName = input.DatabaseName;
+        entity.SchemaOnly = input.SchemaOnly;
+        entity.DumpStatus = DumpStatus.Pending;
+        await Repository.UpdateAsync(entity);
+        await CurrentUnitOfWork.SaveChangesAsync();
+
+        Logger.Info($"[UpdateSettings] Updated settings for connection {input.Id}. DatabaseName={input.DatabaseName}, SchemaOnly={input.SchemaOnly}. Enqueueing dump.");
+
+        await _backgroundJobManager.EnqueueAsync<DatabaseDumpJob, DatabaseDumpArgs>(
+            new DatabaseDumpArgs { ConnectionId = entity.Id, SchemaOnly = entity.SchemaOnly });
+    }
+
+    /// <summary>
     /// Manually enqueues a database dump for an existing connection.
     /// </summary>
     public async Task TriggerDumpAsync(Guid connectionId)

--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/DatabaseConnectionService/IDatabaseConnectionAppService.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/DatabaseConnectionService/IDatabaseConnectionAppService.cs
@@ -23,6 +23,12 @@ public interface IDatabaseConnectionAppService
     Task<DatabaseConnectionDto> SaveConnectionAsync(CreateDatabaseConnectionInput input);
 
     /// <summary>
+    /// Updates the DatabaseName and SchemaOnly settings of an existing connection,
+    /// then re-triggers the dump pipeline so the change takes effect immediately.
+    /// </summary>
+    Task UpdateSettingsAsync(UpdateConnectionSettingsInput input);
+
+    /// <summary>
     /// Manually enqueues a database dump for an existing connection.
     /// </summary>
     Task TriggerDumpAsync(Guid connectionId);

--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/DatabaseConnectionService/Jobs/DatabaseDumpJob.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/DatabaseConnectionService/Jobs/DatabaseDumpJob.cs
@@ -98,7 +98,9 @@ public class DatabaseDumpJob
         DatabaseConnection connection, string outputPath, bool schemaOnly)
     {
         var database = string.IsNullOrWhiteSpace(connection.DatabaseName) ? "postgres" : connection.DatabaseName;
-        var connString = $"postgresql://{connection.DbUser}:{Uri.EscapeDataString(connection.DbPassword)}@{connection.DbHost}:{connection.DbPort}/{database}";
+        // Strip pooler suffix — pg_dump requires a direct (non-pooled) connection
+        var host = connection.DbHost.Replace("-pooler", "", StringComparison.OrdinalIgnoreCase);
+        var connString = $"postgresql://{connection.DbUser}:{Uri.EscapeDataString(connection.DbPassword)}@{host}:{connection.DbPort}/{database}?sslmode=require";
 
         var psi = new ProcessStartInfo
         {

--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/IQueryExecutionAppService.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/IQueryExecutionAppService.cs
@@ -1,3 +1,4 @@
+using System;
 using System.Collections.Generic;
 using System.Threading.Tasks;
 using Abp.Application.Services;
@@ -18,7 +19,7 @@ public interface IQueryExecutionAppService : IApplicationService
     /// <summary>
     /// Returns all user tables and their columns from the local copy of the given connection's database.
     /// </summary>
-    Task<List<SchemaTableDto>> GetSchemaAsync(GetSchemaInput input);
+    Task<List<SchemaTableDto>> GetSchemaAsync(Guid connectionId);
 
     /// <summary>
     /// Runs EXPLAIN ANALYZE on the query, then asks the AI to suggest an optimised version.

--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/QueryExecutionAppService.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/QueryExecutionAppService.cs
@@ -7,6 +7,7 @@ using System.Threading.Tasks;
 using Abp.Application.Services;
 using Abp.Authorization;
 using Abp.Domain.Repositories;
+using Abp.UI;
 using Npgsql;
 using OpenAI.Chat;
 using sql_optimizer.Core.Domains.Database;
@@ -81,11 +82,11 @@ public class QueryExecutionAppService : ApplicationService, IQueryExecutionAppSe
     }
 
     /// <inheritdoc />
-    public async Task<List<SchemaTableDto>> GetSchemaAsync(GetSchemaInput input)
+    public async Task<List<SchemaTableDto>> GetSchemaAsync(Guid connectionId)
     {
-        var connectionString = await GetLocalConnectionStringAsync(input.ConnectionId);
+        var connectionString = await GetLocalConnectionStringAsync(connectionId);
         if (connectionString is null)
-            return [];
+            throw new UserFriendlyException("The local database for this connection no longer exists. Please re-run the restore.");
 
         try
         {
@@ -94,15 +95,19 @@ public class QueryExecutionAppService : ApplicationService, IQueryExecutionAppSe
 
             const string sql = """
                 SELECT
-                    t.table_name,
+                    CASE WHEN t.table_schema = 'public' THEN t.table_name
+                         ELSE t.table_schema || '.' || t.table_name
+                    END AS table_name,
                     c.column_name
                 FROM information_schema.tables t
                 JOIN information_schema.columns c
                     ON c.table_schema = t.table_schema
                     AND c.table_name  = t.table_name
-                WHERE t.table_schema = 'public'
-                  AND t.table_type   = 'BASE TABLE'
-                ORDER BY t.table_name, c.ordinal_position;
+                WHERE t.table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
+                  AND t.table_schema NOT LIKE 'pg_temp_%'
+                  AND t.table_schema NOT LIKE 'pg_toast_temp_%'
+                  AND t.table_type = 'BASE TABLE'
+                ORDER BY t.table_schema, t.table_name, c.ordinal_position;
                 """;
 
             await using var cmd = new NpgsqlCommand(sql, conn);
@@ -127,8 +132,8 @@ public class QueryExecutionAppService : ApplicationService, IQueryExecutionAppSe
         }
         catch (Exception ex)
         {
-            Logger.Error($"[QueryExecution] Schema fetch failed for connection {input.ConnectionId}: {ex.Message}", ex);
-            return [];
+            Logger.Error($"[QueryExecution] Schema fetch failed for connection {connectionId}: {ex.Message}", ex);
+            throw new UserFriendlyException($"Could not read schema: {ex.Message}");
         }
     }
 
@@ -164,7 +169,7 @@ public class QueryExecutionAppService : ApplicationService, IQueryExecutionAppSe
         }
 
         // 2. Fetch schema for context
-        var schema = await GetSchemaAsync(new GetSchemaInput { ConnectionId = input.ConnectionId });
+        var schema = await GetSchemaAsync(input.ConnectionId);
         var schemaText = string.Join("\n", schema.Select(t =>
             $"  {t.Name}({string.Join(", ", t.Columns)})"));
 

--- a/Frontend/src/app/dashboard/databases/AddConnectionForm/AddConnectionForm.tsx
+++ b/Frontend/src/app/dashboard/databases/AddConnectionForm/AddConnectionForm.tsx
@@ -29,6 +29,7 @@ interface IConnectionFormValues {
     port: string;
     username: string;
     password: string;
+    databaseName: string;
 }
 
 const INITIAL_VALUES: IConnectionFormValues = {
@@ -38,6 +39,7 @@ const INITIAL_VALUES: IConnectionFormValues = {
     port: "5432",
     username: "",
     password: "",
+    databaseName: "",
 };
 
 interface IAddConnectionFormProps {
@@ -78,6 +80,7 @@ const AddConnectionForm: React.FC<IAddConnectionFormProps> = ({ onSaved }) => {
                 dbPort: parseInt(values.port, 10) || 5432,
                 dbUser: values.username,
                 dbPassword: values.password,
+                databaseName: values.databaseName || undefined,
                 databaseType: DATABASE_TYPE_MAP[values.engine] ?? 2,
                 requireSsl: true,
             });
@@ -114,6 +117,7 @@ const AddConnectionForm: React.FC<IAddConnectionFormProps> = ({ onSaved }) => {
                     dbPort: parseInt(values.port, 10) || 5432,
                     dbUser: values.username,
                     dbPassword: values.password,
+                    databaseName: values.databaseName || undefined,
                     databaseType: DATABASE_TYPE_MAP[values.engine] ?? 2,
                     requireSsl: true,
                     schemaOnly,
@@ -196,6 +200,15 @@ const AddConnectionForm: React.FC<IAddConnectionFormProps> = ({ onSaved }) => {
                         value={values.password}
                         onChange={(event) => setField("password", event.target.value)}
                         prefix={<KeyOutlined />}
+                    />
+                </div>
+                <div>
+                    <label className={styles.formLabel} htmlFor="conn-db-name">Database Name</label>
+                    <Input
+                        id="conn-db-name"
+                        value={values.databaseName}
+                        onChange={(event) => setField("databaseName", event.target.value)}
+                        placeholder="e.g. neondb"
                     />
                 </div>
             </div>

--- a/Frontend/src/app/dashboard/databases/ConnectionCard/ConnectionCard.tsx
+++ b/Frontend/src/app/dashboard/databases/ConnectionCard/ConnectionCard.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { Button } from "antd";
-import { DatabaseOutlined } from "@ant-design/icons";
+import { DatabaseOutlined, EditOutlined } from "@ant-design/icons";
 import { useStyles } from "../style/styles";
 
 /** Connection status values for a database card. */
@@ -32,10 +32,11 @@ export interface IDatabase {
 
 interface IConnectionCardProps {
     database: IDatabase;
+    onEdit: () => void;
 }
 
 /** Card displaying a single database connection's metadata and status. */
-const ConnectionCard: React.FC<IConnectionCardProps> = ({ database }) => {
+const ConnectionCard: React.FC<IConnectionCardProps> = ({ database, onEdit }) => {
     const { styles } = useStyles();
 
     return (
@@ -66,7 +67,7 @@ const ConnectionCard: React.FC<IConnectionCardProps> = ({ database }) => {
                 <span className={database.isLocalReady ? styles.badgeConnected : styles.badgeDisconnected}>
                     {database.restoreStatus}
                 </span>
-                <Button type="text" size="small">Configure</Button>
+                <Button type="text" size="small" icon={<EditOutlined />} onClick={onEdit}>Edit</Button>
             </div>
         </div>
     );

--- a/Frontend/src/app/dashboard/databases/ConnectionCardList/ConnectionCardList.tsx
+++ b/Frontend/src/app/dashboard/databases/ConnectionCardList/ConnectionCardList.tsx
@@ -8,10 +8,11 @@ import { useStyles } from "../style/styles";
 interface IConnectionCardListProps {
     databases: IDatabase[];
     isLoading: boolean;
+    onEdit: (id: string) => void;
 }
 
 /** Grid of all registered database connection cards. */
-const ConnectionCardList: React.FC<IConnectionCardListProps> = ({ databases, isLoading }) => {
+const ConnectionCardList: React.FC<IConnectionCardListProps> = ({ databases, isLoading, onEdit }) => {
     const { styles } = useStyles();
 
     if (isLoading) {
@@ -31,7 +32,7 @@ const ConnectionCardList: React.FC<IConnectionCardListProps> = ({ databases, isL
     return (
         <div className={styles.cardsGrid}>
             {databases.map((database) => (
-                <ConnectionCard key={database.id} database={database} />
+                <ConnectionCard key={database.id} database={database} onEdit={() => onEdit(database.id)} />
             ))}
         </div>
     );

--- a/Frontend/src/app/dashboard/databases/EditConnectionModal/EditConnectionModal.tsx
+++ b/Frontend/src/app/dashboard/databases/EditConnectionModal/EditConnectionModal.tsx
@@ -1,0 +1,89 @@
+"use client";
+
+import React, { useState, useEffect } from "react";
+import { Modal, Input, Switch, notification } from "antd";
+import { IDatabaseConnectionDto, updateConnectionSettings } from "@/services/databaseConnectionService";
+
+interface IEditConnectionModalProps {
+    /** The connection being edited, or null when the modal is closed. */
+    connection: IDatabaseConnectionDto | null;
+    /** Called when the modal is dismissed without saving. */
+    onClose: () => void;
+    /** Called after a successful save so the list can refresh. */
+    onSaved: () => void;
+}
+
+/** Modal for editing the DatabaseName and SchemaOnly settings of an existing connection. */
+const EditConnectionModal: React.FC<IEditConnectionModalProps> = ({ connection, onClose, onSaved }) => {
+    const [databaseName, setDatabaseName] = useState<string>("");
+    const [schemaOnly, setSchemaOnly] = useState<boolean>(false);
+    const [isSaving, setIsSaving] = useState<boolean>(false);
+
+    useEffect(() => {
+        if (connection) {
+            setDatabaseName(connection.databaseName ?? "");
+            setSchemaOnly(connection.schemaOnly);
+        }
+    }, [connection]);
+
+    const handleSave = async (): Promise<void> => {
+        if (!connection) {
+            return;
+        }
+
+        setIsSaving(true);
+        try {
+            await updateConnectionSettings({
+                id: connection.id,
+                databaseName: databaseName.trim() || undefined,
+                schemaOnly,
+            });
+
+            notification.success({ message: "Settings saved. A new dump has been queued." });
+            onSaved();
+        } catch (error) {
+            const message = error instanceof Error ? error.message : "An unexpected error occurred.";
+            notification.error({ message: "Failed to save settings", description: message });
+        } finally {
+            setIsSaving(false);
+        }
+    };
+
+    return (
+        <Modal
+            title={`Edit Connection — ${connection?.name ?? ""}`}
+            open={!!connection}
+            onOk={() => { void handleSave(); }}
+            onCancel={onClose}
+            okText="Save & Re-dump"
+            confirmLoading={isSaving}
+            destroyOnHidden
+        >
+            <div style={{ display: "flex", flexDirection: "column", gap: 16, marginTop: 8 }}>
+                <div>
+                    <label htmlFor="edit-db-name" style={{ display: "block", fontSize: 13, fontWeight: 500, marginBottom: 6 }}>
+                        Database Name
+                    </label>
+                    <Input
+                        id="edit-db-name"
+                        value={databaseName}
+                        onChange={(event) => setDatabaseName(event.target.value)}
+                        placeholder="e.g. neondb"
+                    />
+                </div>
+                <div style={{ display: "flex", alignItems: "center", gap: 10 }}>
+                    <Switch
+                        id="edit-schema-only"
+                        checked={schemaOnly}
+                        onChange={setSchemaOnly}
+                    />
+                    <label htmlFor="edit-schema-only" style={{ fontSize: 13, fontWeight: 500 }}>
+                        Schema only (copy structure, no data)
+                    </label>
+                </div>
+            </div>
+        </Modal>
+    );
+};
+
+export default EditConnectionModal;

--- a/Frontend/src/app/dashboard/databases/page.tsx
+++ b/Frontend/src/app/dashboard/databases/page.tsx
@@ -4,6 +4,7 @@ import React, { useEffect, useState, useCallback } from "react";
 import DatabasesHeader from "./DatabasesHeader/DatabasesHeader";
 import ConnectionCardList from "./ConnectionCardList/ConnectionCardList";
 import AddConnectionForm from "./AddConnectionForm/AddConnectionForm";
+import EditConnectionModal from "./EditConnectionModal/EditConnectionModal";
 import { getDatabaseConnections, IDatabaseConnectionDto, DATABASE_ENGINE_NAMES, RESTORE_STATUS_LABELS } from "@/services/databaseConnectionService";
 import { IDatabase } from "./ConnectionCard/ConnectionCard";
 
@@ -24,13 +25,16 @@ function mapToDatabase(dto: IDatabaseConnectionDto): IDatabase {
 
 /** Databases page — view registered connections and add new ones. */
 export default function DatabasesPage(): React.JSX.Element {
+    const [rawConnections, setRawConnections] = useState<IDatabaseConnectionDto[]>([]);
     const [databases, setDatabases] = useState<IDatabase[]>([]);
     const [isLoading, setIsLoading] = useState<boolean>(true);
+    const [editingConnection, setEditingConnection] = useState<IDatabaseConnectionDto | null>(null);
 
     const fetchConnections = useCallback(async (): Promise<void> => {
         setIsLoading(true);
         try {
             const items = await getDatabaseConnections();
+            setRawConnections(items);
             setDatabases(items.map(mapToDatabase));
         } finally {
             setIsLoading(false);
@@ -41,11 +45,26 @@ export default function DatabasesPage(): React.JSX.Element {
         void fetchConnections();
     }, [fetchConnections]);
 
+    const handleEdit = (id: string): void => {
+        const connection = rawConnections.find((c) => c.id === id) ?? null;
+        setEditingConnection(connection);
+    };
+
+    const handleEditSaved = (): void => {
+        setEditingConnection(null);
+        void fetchConnections();
+    };
+
     return (
         <>
             <DatabasesHeader />
-            <ConnectionCardList databases={databases} isLoading={isLoading} />
+            <ConnectionCardList databases={databases} isLoading={isLoading} onEdit={handleEdit} />
             <AddConnectionForm onSaved={fetchConnections} />
+            <EditConnectionModal
+                connection={editingConnection}
+                onClose={() => setEditingConnection(null)}
+                onSaved={handleEditSaved}
+            />
         </>
     );
 }

--- a/Frontend/src/app/dashboard/playground/SchemaPanel/SchemaPanel.tsx
+++ b/Frontend/src/app/dashboard/playground/SchemaPanel/SchemaPanel.tsx
@@ -1,7 +1,7 @@
 "use client";
 
 import React, { useState } from "react";
-import { Input } from "antd";
+import { Input, Spin, Alert } from "antd";
 import { TableOutlined, BorderOutlined, SearchOutlined, RightOutlined } from "@ant-design/icons";
 import { useStyles } from "../style/styles";
 
@@ -16,10 +16,13 @@ interface ISchemaTable {
 interface ISchemaPanelProps {
     /** Tables to display in the schema browser. */
     tables: ISchemaTable[];
+    isLoading: boolean;
+    error: string | null;
+    hasConnection: boolean;
 }
 
 /** Left panel displaying a filterable tree of database tables and their columns. */
-const SchemaPanel: React.FC<ISchemaPanelProps> = ({ tables }) => {
+const SchemaPanel: React.FC<ISchemaPanelProps> = ({ tables, isLoading, error, hasConnection }) => {
     const { styles } = useStyles();
     const [filter, setFilter] = useState<string>("");
     const [expandedTables, setExpandedTables] = useState<Set<string>>(new Set(["users"]));
@@ -57,7 +60,21 @@ const SchemaPanel: React.FC<ISchemaPanelProps> = ({ tables }) => {
                 />
             </div>
             <div className={styles.schemaBody}>
-                {filteredTables.map((table) => {
+                {isLoading ? (
+                    <div style={{ display: "flex", justifyContent: "center", padding: 24 }}>
+                        <Spin />
+                    </div>
+                ) : error ? (
+                    <Alert type="error" message={error} style={{ margin: 8 }} />
+                ) : !hasConnection ? (
+                    <div style={{ padding: 16, color: "#8c8c8c", fontSize: 13, textAlign: "center" }}>
+                        Select a connection to view schema
+                    </div>
+                ) : filteredTables.length === 0 ? (
+                    <div style={{ padding: 16, color: "#8c8c8c", fontSize: 13, textAlign: "center" }}>
+                        No tables found
+                    </div>
+                ) : filteredTables.map((table) => {
                     const isExpanded = expandedTables.has(table.name);
                     return (
                         <React.Fragment key={table.name}>

--- a/Frontend/src/app/dashboard/playground/page.tsx
+++ b/Frontend/src/app/dashboard/playground/page.tsx
@@ -37,6 +37,8 @@ export default function PlaygroundPage(): React.JSX.Element {
     const [connections, setConnections] = useState<IDatabaseConnectionDto[]>([]);
     const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
     const [schemaTables, setSchemaTables] = useState<ISchemaTable[]>([]);
+    const [isLoadingSchema, setIsLoadingSchema] = useState(false);
+    const [schemaError, setSchemaError] = useState<string | null>(null);
 
     const [sqlText, setSqlText] = useState<string>(DEFAULT_SQL);
     const [queryResult, setQueryResult] = useState<IQueryResult | null>(null);
@@ -57,8 +59,17 @@ export default function PlaygroundPage(): React.JSX.Element {
 
     // Reload schema when connection changes
     const loadSchema = useCallback(async (connectionId: string): Promise<void> => {
-        const tables = await getSchema(connectionId);
-        setSchemaTables(tables);
+        setIsLoadingSchema(true);
+        setSchemaError(null);
+        try {
+            const tables = await getSchema(connectionId);
+            setSchemaTables(tables);
+        } catch {
+            setSchemaError("Failed to load schema.");
+            setSchemaTables([]);
+        } finally {
+            setIsLoadingSchema(false);
+        }
     }, []);
 
     useEffect(() => {
@@ -135,7 +146,12 @@ export default function PlaygroundPage(): React.JSX.Element {
                 />
             )}
             <div className={styles.threeColumnLayout}>
-                <SchemaPanel tables={schemaTables} />
+                <SchemaPanel
+                    tables={schemaTables}
+                    isLoading={isLoadingSchema}
+                    error={schemaError}
+                    hasConnection={!!selectedConnectionId}
+                />
                 <EditorPanel
                     sqlText={sqlText}
                     onSqlChange={setSqlText}

--- a/Frontend/src/app/dashboard/query-analysis/ResultsPanel/ResultsPanel.tsx
+++ b/Frontend/src/app/dashboard/query-analysis/ResultsPanel/ResultsPanel.tsx
@@ -120,7 +120,7 @@ const ResultsPanel: React.FC<IResultsPanelProps> = ({
                             Benchmark
                         </Button>
                     </div>
-                    <pre className={styles.planBlock} style={{ flex: "none" }}>{result.suggestedQuery}</pre>
+                    <pre className={styles.planBlock}>{result.suggestedQuery}</pre>
                 </>
             )}
             {benchmarkError && (

--- a/Frontend/src/app/dashboard/query-analysis/style/styles.ts
+++ b/Frontend/src/app/dashboard/query-analysis/style/styles.ts
@@ -135,7 +135,7 @@ export const useStyles = createStyles(({ token }) => ({
         background: ${token.colorBgContainer};
         border: 1px solid ${token.colorBorder};
         border-radius: 12px;
-        overflow: hidden;
+        overflow-y: auto;
     `,
 
     emptyState: css`
@@ -202,7 +202,7 @@ export const useStyles = createStyles(({ token }) => ({
     `,
 
     planBlock: css`
-        flex: 1;
+        flex: none;
         overflow: auto;
         margin: 0;
         padding: 16px 20px;

--- a/Frontend/src/constants/ApiConstants.ts
+++ b/Frontend/src/constants/ApiConstants.ts
@@ -9,6 +9,7 @@ export const API_CONSTANTS = {
     TEST_CONNECTION: `${API_BASE_URL}/api/services/app/databaseConnection/testConnection`,
     SAVE_CONNECTION: `${API_BASE_URL}/api/services/app/databaseConnection/saveConnection`,
     GET_ALL_CONNECTIONS: `${API_BASE_URL}/api/services/app/databaseConnection/getAll`,
+    UPDATE_CONNECTION_SETTINGS: `${API_BASE_URL}/api/services/app/databaseConnection/updateSettings`,
     EXECUTE_QUERY: `${API_BASE_URL}/api/services/app/queryExecution/execute`,
     GET_SCHEMA: `${API_BASE_URL}/api/services/app/queryExecution/getSchema`,
     ANALYSE_QUERY: `${API_BASE_URL}/api/services/app/queryExecution/analyse`,

--- a/Frontend/src/services/databaseConnectionService.ts
+++ b/Frontend/src/services/databaseConnectionService.ts
@@ -58,6 +58,7 @@ export interface IDatabaseConnectionDto {
     dbHost: string;
     dbPort: number;
     dbUser: string;
+    databaseName: string | null;
     databaseType: number;
     lastSyncTime: string;
     schemaOnly: boolean;
@@ -77,6 +78,29 @@ export async function getDatabaseConnections(): Promise<IDatabaseConnectionDto[]
 
     const json = await response.json();
     return (json.result?.items ?? []) as IDatabaseConnectionDto[];
+}
+
+export interface IUpdateConnectionSettingsRequest {
+    id: string;
+    databaseName: string | undefined;
+    schemaOnly: boolean;
+}
+
+/** Updates the DatabaseName and SchemaOnly settings of an existing connection. */
+export async function updateConnectionSettings(request: IUpdateConnectionSettingsRequest): Promise<void> {
+    const response = await fetch(API_CONSTANTS.UPDATE_CONNECTION_SETTINGS, {
+        method: "PUT",
+        headers: {
+            "Content-Type": "application/json",
+            "Authorization": `Bearer ${tokenService.getToken()}`,
+        },
+        body: JSON.stringify(request),
+    });
+
+    if (!response.ok) {
+        const json = await response.json().catch(() => ({}));
+        throw new Error(json.error?.message ?? "Failed to update connection settings.");
+    }
 }
 
 /** Calls the backend test-connection endpoint and returns the result. */

--- a/Frontend/src/services/queryService.ts
+++ b/Frontend/src/services/queryService.ts
@@ -86,11 +86,15 @@ export async function benchmarkQuery(request: IBenchmarkRequest): Promise<IBench
 
 /** Fetches the schema (tables + columns) for the local copy of the given connection's database. */
 export async function getSchema(connectionId: string): Promise<ISchemaTable[]> {
-    const response = await fetch(API_CONSTANTS.GET_SCHEMA, {
-        method: "POST",
+    const url = `${API_CONSTANTS.GET_SCHEMA}?connectionId=${encodeURIComponent(connectionId)}`;
+    const response = await fetch(url, {
+        method: "GET",
         headers: authHeaders(),
-        body: JSON.stringify({ connectionId }),
     });
+
+    if (!response.ok) {
+        throw new Error(`Schema fetch failed: ${response.status}`);
+    }
 
     const json = await response.json();
     return (json.result ?? []) as ISchemaTable[];

--- a/Frontend/tests/playground.spec.ts
+++ b/Frontend/tests/playground.spec.ts
@@ -31,4 +31,9 @@ test.describe("Playground", () => {
         await page.goto("/dashboard/playground");
         await expect(page.getByText("Connection")).toBeVisible();
     });
+
+    test("SchemaPanel shows placeholder when no connection is selected", async ({ page }) => {
+        await page.goto("/dashboard/playground");
+        await expect(page.getByText("Select a connection to view schema")).toBeVisible();
+    });
 });


### PR DESCRIPTION
## Summary

- **Fix schema panel not showing tables** — added loading/error/empty states; fixed ABP Classic GET binding by replacing complex DTO with a primitive `Guid` parameter; expanded schema query to all user schemas (not just `public`); stripped `-pooler` suffix and added `sslmode=require` to `pg_dump` connection URI for Neon compatibility
- **Add Database Name field to connection form** — users can now specify the target database name (e.g. `neondb`) when adding a connection
- **Add Edit button to connection cards** — opens a modal to update `DatabaseName` and `SchemaOnly` on an existing connection and re-triggers the dump pipeline
- **Fix AI analysis results not scrollable** — `resultsPanel` was `overflow: hidden`, clipping the benchmark card when the suggested query was long; changed to `overflow-y: auto` and `planBlock` to `flex: none`
- **Restore `--schema-only` flag** in `DatabaseDumpJob` after it was accidentally removed by the linter

## Closes

Closes #73

