### PR TITLE
feat: Add Dump and Rebuild controls to Databases page

### DIFF
--- a/Frontend/src/app/dashboard/databases/ConnectionCard/ConnectionCard.tsx
+++ b/Frontend/src/app/dashboard/databases/ConnectionCard/ConnectionCard.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import React from "react";
-import { Button } from "antd";
-import { DatabaseOutlined, EditOutlined } from "@ant-design/icons";
+import { Button, Tooltip } from "antd";
+import { DatabaseOutlined, EditOutlined, CloudDownloadOutlined, ReloadOutlined } from "@ant-design/icons";
 import { useStyles } from "../style/styles";
 
 /** Connection status values for a database card. */
@@ -28,16 +28,28 @@ export interface IDatabase {
     restoreStatus: string;
     /** Whether a local copy of the database is ready to query. */
     isLocalReady: boolean;
+    /** Raw dump status enum value (0=None,1=Pending,2=InProgress,3=Completed,4=Failed). */
+    dumpStatus: number;
+    /** Raw restore status enum value (0=None,1=Pending,2=InProgress,3=Completed,4=Failed). */
+    restoreStatusRaw: number;
 }
 
 interface IConnectionCardProps {
     database: IDatabase;
     onEdit: () => void;
+    onDump: () => void;
+    onRebuild: () => void;
+    isDumping: boolean;
+    isRebuilding: boolean;
 }
 
 /** Card displaying a single database connection's metadata and status. */
-const ConnectionCard: React.FC<IConnectionCardProps> = ({ database, onEdit }) => {
+const ConnectionCard: React.FC<IConnectionCardProps> = ({ database, onEdit, onDump, onRebuild, isDumping, isRebuilding }) => {
     const { styles } = useStyles();
+
+    const dumpBusy = isDumping || database.dumpStatus === 1 || database.dumpStatus === 2;
+    const rebuildBusy = isRebuilding || database.restoreStatusRaw === 1 || database.restoreStatusRaw === 2;
+    const canRebuild = database.dumpStatus === 3;
 
     return (
         <div className={styles.card}>
@@ -67,6 +79,30 @@ const ConnectionCard: React.FC<IConnectionCardProps> = ({ database, onEdit }) =>
                 <span className={database.isLocalReady ? styles.badgeConnected : styles.badgeDisconnected}>
                     {database.restoreStatus}
                 </span>
+            </div>
+            <div className={styles.cardActions}>
+                <Tooltip title="Dump — capture a fresh snapshot from the live database">
+                    <Button
+                        size="small"
+                        icon={<CloudDownloadOutlined />}
+                        loading={dumpBusy}
+                        disabled={dumpBusy}
+                        onClick={onDump}
+                    >
+                        Dump
+                    </Button>
+                </Tooltip>
+                <Tooltip title={canRebuild ? "Rebuild — restore the latest dump to the local server" : "A completed dump is required before rebuilding"}>
+                    <Button
+                        size="small"
+                        icon={<ReloadOutlined />}
+                        loading={rebuildBusy}
+                        disabled={rebuildBusy || !canRebuild}
+                        onClick={onRebuild}
+                    >
+                        Rebuild
+                    </Button>
+                </Tooltip>
                 <Button type="text" size="small" icon={<EditOutlined />} onClick={onEdit}>Edit</Button>
             </div>
         </div>

--- a/Frontend/src/app/dashboard/databases/ConnectionCardList/ConnectionCardList.tsx
+++ b/Frontend/src/app/dashboard/databases/ConnectionCardList/ConnectionCardList.tsx
@@ -9,10 +9,14 @@ interface IConnectionCardListProps {
     databases: IDatabase[];
     isLoading: boolean;
     onEdit: (id: string) => void;
+    onDump: (id: string) => void;
+    onRebuild: (id: string) => void;
+    dumpingIds: Set<string>;
+    rebuildingIds: Set<string>;
 }
 
 /** Grid of all registered database connection cards. */
-const ConnectionCardList: React.FC<IConnectionCardListProps> = ({ databases, isLoading, onEdit }) => {
+const ConnectionCardList: React.FC<IConnectionCardListProps> = ({ databases, isLoading, onEdit, onDump, onRebuild, dumpingIds, rebuildingIds }) => {
     const { styles } = useStyles();
 
     if (isLoading) {
@@ -32,7 +36,15 @@ const ConnectionCardList: React.FC<IConnectionCardListProps> = ({ databases, isL
     return (
         <div className={styles.cardsGrid}>
             {databases.map((database) => (
-                <ConnectionCard key={database.id} database={database} onEdit={() => onEdit(database.id)} />
+                <ConnectionCard
+                    key={database.id}
+                    database={database}
+                    onEdit={() => onEdit(database.id)}
+                    onDump={() => onDump(database.id)}
+                    onRebuild={() => onRebuild(database.id)}
+                    isDumping={dumpingIds.has(database.id)}
+                    isRebuilding={rebuildingIds.has(database.id)}
+                />
             ))}
         </div>
     );

--- a/Frontend/src/app/dashboard/databases/page.tsx
+++ b/Frontend/src/app/dashboard/databases/page.tsx
@@ -1,11 +1,19 @@
 "use client";
 
-import React, { useEffect, useState, useCallback } from "react";
+import React, { useEffect, useState, useCallback, useRef } from "react";
+import { message } from "antd";
 import DatabasesHeader from "./DatabasesHeader/DatabasesHeader";
 import ConnectionCardList from "./ConnectionCardList/ConnectionCardList";
 import AddConnectionForm from "./AddConnectionForm/AddConnectionForm";
 import EditConnectionModal from "./EditConnectionModal/EditConnectionModal";
-import { getDatabaseConnections, IDatabaseConnectionDto, DATABASE_ENGINE_NAMES, RESTORE_STATUS_LABELS } from "@/services/databaseConnectionService";
+import {
+    getDatabaseConnections,
+    IDatabaseConnectionDto,
+    DATABASE_ENGINE_NAMES,
+    RESTORE_STATUS_LABELS,
+    triggerDump,
+    triggerRestore,
+} from "@/services/databaseConnectionService";
 import { IDatabase } from "./ConnectionCard/ConnectionCard";
 
 /** Maps a backend DTO to the shape expected by ConnectionCard. */
@@ -20,7 +28,17 @@ function mapToDatabase(dto: IDatabaseConnectionDto): IDatabase {
         status: "connected",
         restoreStatus: RESTORE_STATUS_LABELS[dto.restoreStatus] ?? "Unknown",
         isLocalReady: dto.restoreStatus === 3,
+        dumpStatus: dto.dumpStatus,
+        restoreStatusRaw: dto.restoreStatus,
     };
+}
+
+/** Returns true if any connection has a pending or in-progress dump or restore. */
+function hasActiveOperation(items: IDatabaseConnectionDto[]): boolean {
+    return items.some((c) =>
+        c.dumpStatus === 1 || c.dumpStatus === 2 ||
+        c.restoreStatus === 1 || c.restoreStatus === 2,
+    );
 }
 
 /** Databases page — view registered connections and add new ones. */
@@ -29,21 +47,40 @@ export default function DatabasesPage(): React.JSX.Element {
     const [databases, setDatabases] = useState<IDatabase[]>([]);
     const [isLoading, setIsLoading] = useState<boolean>(true);
     const [editingConnection, setEditingConnection] = useState<IDatabaseConnectionDto | null>(null);
+    const [dumpingIds, setDumpingIds] = useState<Set<string>>(new Set());
+    const [rebuildingIds, setRebuildingIds] = useState<Set<string>>(new Set());
+    const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-    const fetchConnections = useCallback(async (): Promise<void> => {
-        setIsLoading(true);
-        try {
-            const items = await getDatabaseConnections();
-            setRawConnections(items);
-            setDatabases(items.map(mapToDatabase));
-        } finally {
-            setIsLoading(false);
-        }
+    const fetchConnections = useCallback(async (): Promise<IDatabaseConnectionDto[]> => {
+        const items = await getDatabaseConnections();
+        setRawConnections(items);
+        setDatabases(items.map(mapToDatabase));
+        return items;
     }, []);
 
-    useEffect(() => {
-        void fetchConnections();
+    const startPolling = useCallback(() => {
+        if (pollTimerRef.current) return;
+        pollTimerRef.current = setInterval(async () => {
+            const items = await fetchConnections();
+            if (!hasActiveOperation(items)) {
+                clearInterval(pollTimerRef.current!);
+                pollTimerRef.current = null;
+            }
+        }, 3000);
     }, [fetchConnections]);
+
+    useEffect(() => {
+        setIsLoading(true);
+        fetchConnections()
+            .then((items) => {
+                if (hasActiveOperation(items)) startPolling();
+            })
+            .finally(() => setIsLoading(false));
+
+        return () => {
+            if (pollTimerRef.current) clearInterval(pollTimerRef.current);
+        };
+    }, [fetchConnections, startPolling]);
 
     const handleEdit = (id: string): void => {
         const connection = rawConnections.find((c) => c.id === id) ?? null;
@@ -52,14 +89,50 @@ export default function DatabasesPage(): React.JSX.Element {
 
     const handleEditSaved = (): void => {
         setEditingConnection(null);
-        void fetchConnections();
+        void fetchConnections().then(startPolling);
+    };
+
+    const handleDump = async (id: string): Promise<void> => {
+        setDumpingIds((prev) => new Set(prev).add(id));
+        try {
+            await triggerDump(id);
+            void message.success("Dump queued — the snapshot will be ready shortly.");
+            await fetchConnections();
+            startPolling();
+        } catch (err) {
+            void message.error(err instanceof Error ? err.message : "Failed to trigger dump.");
+        } finally {
+            setDumpingIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
+        }
+    };
+
+    const handleRebuild = async (id: string): Promise<void> => {
+        setRebuildingIds((prev) => new Set(prev).add(id));
+        try {
+            await triggerRestore(id);
+            void message.success("Rebuild queued — the local copy will be ready shortly.");
+            await fetchConnections();
+            startPolling();
+        } catch (err) {
+            void message.error(err instanceof Error ? err.message : "Failed to trigger rebuild.");
+        } finally {
+            setRebuildingIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
+        }
     };
 
     return (
         <>
             <DatabasesHeader />
-            <ConnectionCardList databases={databases} isLoading={isLoading} onEdit={handleEdit} />
-            <AddConnectionForm onSaved={fetchConnections} />
+            <ConnectionCardList
+                databases={databases}
+                isLoading={isLoading}
+                onEdit={handleEdit}
+                onDump={handleDump}
+                onRebuild={handleRebuild}
+                dumpingIds={dumpingIds}
+                rebuildingIds={rebuildingIds}
+            />
+            <AddConnectionForm onSaved={() => void fetchConnections()} />
             <EditConnectionModal
                 connection={editingConnection}
                 onClose={() => setEditingConnection(null)}

--- a/Frontend/src/app/dashboard/databases/style/styles.ts
+++ b/Frontend/src/app/dashboard/databases/style/styles.ts
@@ -122,9 +122,16 @@ export const useStyles = createStyles(({ token }) => ({
     cardFooter: css`
         display: flex;
         align-items: center;
-        justify-content: space-between;
+        gap: 8px;
         padding-top: 16px;
         border-top: 1px solid ${token.colorBorder};
+    `,
+
+    cardActions: css`
+        display: flex;
+        align-items: center;
+        gap: 8px;
+        padding-top: 12px;
     `,
 
     badgeConnected: css`

--- a/Frontend/src/constants/ApiConstants.ts
+++ b/Frontend/src/constants/ApiConstants.ts
@@ -10,6 +10,8 @@ export const API_CONSTANTS = {
     SAVE_CONNECTION: `${API_BASE_URL}/api/services/app/databaseConnection/saveConnection`,
     GET_ALL_CONNECTIONS: `${API_BASE_URL}/api/services/app/databaseConnection/getAll`,
     UPDATE_CONNECTION_SETTINGS: `${API_BASE_URL}/api/services/app/databaseConnection/updateSettings`,
+    TRIGGER_DUMP: `${API_BASE_URL}/api/services/app/databaseConnection/triggerDump`,
+    TRIGGER_RESTORE: `${API_BASE_URL}/api/services/app/databaseConnection/triggerRestore`,
     EXECUTE_QUERY: `${API_BASE_URL}/api/services/app/queryExecution/execute`,
     GET_SCHEMA: `${API_BASE_URL}/api/services/app/queryExecution/getSchema`,
     ANALYSE_QUERY: `${API_BASE_URL}/api/services/app/queryExecution/analyse`,

--- a/Frontend/src/services/databaseConnectionService.ts
+++ b/Frontend/src/services/databaseConnectionService.ts
@@ -103,6 +103,36 @@ export async function updateConnectionSettings(request: IUpdateConnectionSetting
     }
 }
 
+/** Manually triggers a fresh database dump for an existing connection. */
+export async function triggerDump(connectionId: string): Promise<void> {
+    const response = await fetch(`${API_CONSTANTS.TRIGGER_DUMP}?connectionId=${connectionId}`, {
+        method: "POST",
+        headers: {
+            "Authorization": `Bearer ${tokenService.getToken()}`,
+        },
+    });
+
+    if (!response.ok) {
+        const json = await response.json().catch(() => ({}));
+        throw new Error(json.error?.message ?? "Failed to trigger dump.");
+    }
+}
+
+/** Manually triggers a restore of the latest dump into the local server database. */
+export async function triggerRestore(connectionId: string): Promise<void> {
+    const response = await fetch(`${API_CONSTANTS.TRIGGER_RESTORE}?connectionId=${connectionId}`, {
+        method: "POST",
+        headers: {
+            "Authorization": `Bearer ${tokenService.getToken()}`,
+        },
+    });
+
+    if (!response.ok) {
+        const json = await response.json().catch(() => ({}));
+        throw new Error(json.error?.message ?? "Failed to trigger restore.");
+    }
+}
+
 /** Calls the backend test-connection endpoint and returns the result. */
 export async function testConnection(request: ITestConnectionRequest): Promise<ITestConnectionResponse> {
     const response = await fetch(API_CONSTANTS.TEST_CONNECTION, {


### PR DESCRIPTION
## Summary

- Each connection card now has **Dump** and **Rebuild** action buttons
- **Dump** — queues a fresh `pg_dump` snapshot from the live database (`TriggerDumpAsync`)
- **Rebuild** — restores the latest dump to the local server-side PostgreSQL instance (`TriggerRestoreAsync`)
- Buttons show a loading spinner while an operation is pending or in-progress
- Rebuild is disabled until a successful dump exists (dumpStatus = Completed)
- Page polls every 3 s while any connection has an active operation, then stops automatically
- Toast notifications confirm when an operation is queued or fails

## Issues closed

Closes #39
Closes #82
