### PR TITLE
fix: Remove null from ISchemaColumnDto.highlight (build fix)

### DIFF
--- a/Frontend/src/services/schemaAdvisorService.ts
+++ b/Frontend/src/services/schemaAdvisorService.ts
@@ -4,7 +4,7 @@ import { tokenService } from "./tokenService";
 export interface ISchemaColumnDto {
     name: string;
     type: string;
-    highlight?: "warning" | "new" | null;
+    highlight?: "warning" | "new";
 }
 
 export interface ISchemaTableDefDto {


### PR DESCRIPTION
## Summary

Removes `null` from `ISchemaColumnDto.highlight` in `schemaAdvisorService.ts`. The `RefactoringPanel` component's `ISchemaColumn` type only accepts `"warning" | "new" | undefined`, so the extra `null` caused a TypeScript type error that failed `npm run build`.
