### PR TITLE
feat: React Context providers, Schema Advisor history, and schema-only data generator

### DIFF
--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/DatabaseConnectionService/DTO/DatabaseConnectionDto.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/DatabaseConnectionService/DTO/DatabaseConnectionDto.cs
@@ -33,6 +33,8 @@ public class DatabaseConnectionDto : EntityDto<Guid>
 
     public DateTime LastSyncTime { get; set; }
 
+    public bool SchemaOnly { get; set; }
+
     public DumpStatus DumpStatus { get; set; }
 
     public string DumpFilePath { get; set; }

--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/DTO/GenerateTestDataInput.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/DTO/GenerateTestDataInput.cs
@@ -1,0 +1,23 @@
+using System;
+using System.Collections.Generic;
+using System.ComponentModel.DataAnnotations;
+
+namespace sql_optimizer.Services.QueryExecutionService.DTO;
+
+public class TableRowCountInput
+{
+    [Required]
+    public string TableName { get; set; }
+
+    [Range(1, 1000)]
+    public int RowCount { get; set; } = 10;
+}
+
+public class GenerateTestDataInput
+{
+    [Required]
+    public Guid ConnectionId { get; set; }
+
+    [Required]
+    public List<TableRowCountInput> Tables { get; set; } = [];
+}

--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/DTO/GenerateTestDataOutput.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/DTO/GenerateTestDataOutput.cs
@@ -1,0 +1,11 @@
+using System.Collections.Generic;
+
+namespace sql_optimizer.Services.QueryExecutionService.DTO;
+
+public class GenerateTestDataOutput
+{
+    public bool Success { get; set; }
+    /// <summary>Number of rows inserted per table name.</summary>
+    public Dictionary<string, int> InsertedCounts { get; set; } = [];
+    public string Error { get; set; }
+}

--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/DTO/SchemaColumnDto.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/DTO/SchemaColumnDto.cs
@@ -1,0 +1,14 @@
+namespace sql_optimizer.Services.QueryExecutionService.DTO;
+
+public class SchemaColumnDto
+{
+    public string Name { get; set; }
+    public string DataType { get; set; }
+    public bool IsNullable { get; set; }
+    public bool IsPrimaryKey { get; set; }
+    public int? MaxLength { get; set; }
+    /// <summary>Table this column references via FK, or null.</summary>
+    public string ReferencesTable { get; set; }
+    /// <summary>Column this column references via FK, or null.</summary>
+    public string ReferencesColumn { get; set; }
+}

--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/DTO/SchemaRelationshipDto.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/DTO/SchemaRelationshipDto.cs
@@ -1,0 +1,9 @@
+namespace sql_optimizer.Services.QueryExecutionService.DTO;
+
+public class SchemaRelationshipDto
+{
+    public string FromTable { get; set; }
+    public string FromColumn { get; set; }
+    public string ToTable { get; set; }
+    public string ToColumn { get; set; }
+}

--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/DTO/SchemaTableDetailDto.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/DTO/SchemaTableDetailDto.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace sql_optimizer.Services.QueryExecutionService.DTO;
+
+public class SchemaTableDetailDto
+{
+    public string Name { get; set; }
+    public List<SchemaColumnDto> Columns { get; set; } = [];
+}

--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/DTO/SchemaWithRelationshipsDto.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/DTO/SchemaWithRelationshipsDto.cs
@@ -1,0 +1,9 @@
+using System.Collections.Generic;
+
+namespace sql_optimizer.Services.QueryExecutionService.DTO;
+
+public class SchemaWithRelationshipsDto
+{
+    public List<SchemaTableDetailDto> Tables { get; set; } = [];
+    public List<SchemaRelationshipDto> Relationships { get; set; } = [];
+}

--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/IQueryExecutionAppService.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/IQueryExecutionAppService.cs
@@ -22,6 +22,16 @@ public interface IQueryExecutionAppService : IApplicationService
     Task<List<SchemaTableDto>> GetSchemaAsync(Guid connectionId);
 
     /// <summary>
+    /// Returns all user tables with detailed column metadata (type, nullable, PK, FK) and FK relationships.
+    /// </summary>
+    Task<SchemaWithRelationshipsDto> GetSchemaWithRelationshipsAsync(Guid connectionId);
+
+    /// <summary>
+    /// Uses AI to generate and insert test data into the local database respecting FK constraints.
+    /// </summary>
+    Task<GenerateTestDataOutput> GenerateTestDataAsync(GenerateTestDataInput input);
+
+    /// <summary>
     /// Runs EXPLAIN ANALYZE on the query, then asks the AI to suggest an optimised version.
     /// </summary>
     Task<AnalyseQueryOutput> AnalyseAsync(AnalyseQueryInput input);

--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/QueryExecutionAppService.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/QueryExecutionService/QueryExecutionAppService.cs
@@ -138,6 +138,307 @@ public class QueryExecutionAppService : ApplicationService, IQueryExecutionAppSe
     }
 
     /// <inheritdoc />
+    public async Task<SchemaWithRelationshipsDto> GetSchemaWithRelationshipsAsync(Guid connectionId)
+    {
+        var connectionString = await GetLocalConnectionStringAsync(connectionId);
+        if (connectionString is null)
+            throw new UserFriendlyException("The local database for this connection has not been restored yet.");
+
+        try
+        {
+            await using var conn = new NpgsqlConnection(connectionString);
+            await conn.OpenAsync();
+
+            // Columns with PK info
+            const string columnSql = """
+                SELECT
+                    CASE WHEN c.table_schema = 'public' THEN c.table_name
+                         ELSE c.table_schema || '.' || c.table_name
+                    END AS table_name,
+                    c.column_name,
+                    c.data_type,
+                    c.is_nullable,
+                    c.character_maximum_length,
+                    CASE WHEN pk.column_name IS NOT NULL THEN true ELSE false END AS is_primary_key
+                FROM information_schema.columns c
+                JOIN information_schema.tables t
+                    ON t.table_schema = c.table_schema AND t.table_name = c.table_name
+                LEFT JOIN (
+                    SELECT kcu.table_schema, kcu.table_name, kcu.column_name
+                    FROM information_schema.table_constraints tc
+                    JOIN information_schema.key_column_usage kcu
+                        ON kcu.constraint_name = tc.constraint_name
+                        AND kcu.table_schema = tc.table_schema
+                    WHERE tc.constraint_type = 'PRIMARY KEY'
+                ) pk ON pk.table_schema = c.table_schema AND pk.table_name = c.table_name AND pk.column_name = c.column_name
+                WHERE t.table_schema NOT IN ('information_schema', 'pg_catalog', 'pg_toast')
+                  AND t.table_schema NOT LIKE 'pg_temp_%'
+                  AND t.table_type = 'BASE TABLE'
+                ORDER BY c.table_schema, c.table_name, c.ordinal_position;
+                """;
+
+            // FK relationships
+            const string fkSql = """
+                SELECT
+                    CASE WHEN kcu.table_schema = 'public' THEN kcu.table_name
+                         ELSE kcu.table_schema || '.' || kcu.table_name
+                    END AS from_table,
+                    kcu.column_name AS from_column,
+                    CASE WHEN ccu.table_schema = 'public' THEN ccu.table_name
+                         ELSE ccu.table_schema || '.' || ccu.table_name
+                    END AS to_table,
+                    ccu.column_name AS to_column
+                FROM information_schema.table_constraints tc
+                JOIN information_schema.key_column_usage kcu
+                    ON kcu.constraint_name = tc.constraint_name AND kcu.table_schema = tc.table_schema
+                JOIN information_schema.constraint_column_usage ccu
+                    ON ccu.constraint_name = tc.constraint_name AND ccu.table_schema = tc.table_schema
+                WHERE tc.constraint_type = 'FOREIGN KEY';
+                """;
+
+            var tables = new Dictionary<string, SchemaTableDetailDto>();
+
+            await using (var cmd = new NpgsqlCommand(columnSql, conn))
+            await using (var reader = await cmd.ExecuteReaderAsync())
+            {
+                while (await reader.ReadAsync())
+                {
+                    var tableName = reader.GetString(0);
+                    if (!tables.TryGetValue(tableName, out var table))
+                    {
+                        table = new SchemaTableDetailDto { Name = tableName };
+                        tables[tableName] = table;
+                    }
+
+                    table.Columns.Add(new SchemaColumnDto
+                    {
+                        Name = reader.GetString(1),
+                        DataType = reader.GetString(2),
+                        IsNullable = reader.GetString(3) == "YES",
+                        MaxLength = reader.IsDBNull(4) ? null : reader.GetInt32(4),
+                        IsPrimaryKey = reader.GetBoolean(5),
+                    });
+                }
+            }
+
+            var relationships = new List<SchemaRelationshipDto>();
+
+            await using (var cmd = new NpgsqlCommand(fkSql, conn))
+            await using (var reader = await cmd.ExecuteReaderAsync())
+            {
+                while (await reader.ReadAsync())
+                {
+                    var fromTable = reader.GetString(0);
+                    var fromColumn = reader.GetString(1);
+                    var toTable = reader.GetString(2);
+                    var toColumn = reader.GetString(3);
+
+                    relationships.Add(new SchemaRelationshipDto
+                    {
+                        FromTable = fromTable,
+                        FromColumn = fromColumn,
+                        ToTable = toTable,
+                        ToColumn = toColumn,
+                    });
+
+                    // Annotate FK info onto columns
+                    if (tables.TryGetValue(fromTable, out var table))
+                    {
+                        var col = table.Columns.FirstOrDefault(c => c.Name == fromColumn);
+                        if (col is not null)
+                        {
+                            col.ReferencesTable = toTable;
+                            col.ReferencesColumn = toColumn;
+                        }
+                    }
+                }
+            }
+
+            return new SchemaWithRelationshipsDto
+            {
+                Tables = [.. tables.Values],
+                Relationships = relationships,
+            };
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"[Schema] GetSchemaWithRelationships failed for {connectionId}: {ex.Message}", ex);
+            throw new UserFriendlyException($"Could not read schema: {ex.Message}");
+        }
+    }
+
+    /// <inheritdoc />
+    public async Task<GenerateTestDataOutput> GenerateTestDataAsync(GenerateTestDataInput input)
+    {
+        var connectionString = await GetLocalConnectionStringAsync(input.ConnectionId);
+        if (connectionString is null)
+            return new GenerateTestDataOutput { Error = "This connection has not been restored to the local database yet." };
+
+        var openAiKey = Environment.GetEnvironmentVariable("OPENAI_KEY");
+        if (string.IsNullOrWhiteSpace(openAiKey))
+            return new GenerateTestDataOutput { Error = "OPENAI_KEY environment variable is not configured." };
+
+        // Build schema context for requested tables only
+        SchemaWithRelationshipsDto schema;
+        try
+        {
+            schema = await GetSchemaWithRelationshipsAsync(input.ConnectionId);
+        }
+        catch (Exception ex)
+        {
+            return new GenerateTestDataOutput { Error = $"Could not read schema: {ex.Message}" };
+        }
+
+        var requestedNames = new HashSet<string>(input.Tables.Select(t => t.TableName), StringComparer.OrdinalIgnoreCase);
+        var requestedTables = schema.Tables.Where(t => requestedNames.Contains(t.Name)).ToList();
+
+        if (requestedTables.Count == 0)
+            return new GenerateTestDataOutput { Error = "None of the requested tables were found in the schema." };
+
+        // Topological sort by FK dependencies so parents are inserted before children
+        var sorted = TopologicalSort(requestedTables, schema.Relationships);
+
+        // Build prompt
+        var schemaText = string.Join("\n", sorted.Select(t =>
+        {
+            var cols = string.Join(", ", t.Columns.Select(c =>
+            {
+                var desc = $"{c.Name} {c.DataType}";
+                if (c.IsPrimaryKey) desc += " PK";
+                if (!c.IsNullable) desc += " NOT NULL";
+                if (c.ReferencesTable != null) desc += $" FK->{c.ReferencesTable}.{c.ReferencesColumn}";
+                return desc;
+            }));
+            var rowCount = input.Tables.FirstOrDefault(r => string.Equals(r.TableName, t.Name, StringComparison.OrdinalIgnoreCase))?.RowCount ?? 10;
+            return $"  {t.Name}({cols}) -- generate {rowCount} rows";
+        }));
+
+        var relevantFks = schema.Relationships
+            .Where(r => requestedNames.Contains(r.FromTable) && requestedNames.Contains(r.ToTable))
+            .ToList();
+
+        var fkText = relevantFks.Count > 0
+            ? string.Join("\n", relevantFks.Select(r => $"  {r.FromTable}.{r.FromColumn} -> {r.ToTable}.{r.ToColumn}"))
+            : "  (none)";
+
+        var systemPrompt = """
+            You are a PostgreSQL test data generator.
+            Given a schema and FK constraints, generate SQL INSERT statements that:
+            - Respect column data types
+            - Respect NOT NULL constraints
+            - Insert parent table rows before child table rows (FK order is already provided)
+            - Use realistic but fictional values
+            - Do NOT include any markdown, code fences, or explanations — only raw SQL statements separated by semicolons
+            - Use single quotes for string literals; escape apostrophes as ''
+            - Do not include a trailing semicolon after the last statement
+            """;
+
+        var userMessage = $"""
+            Schema (in FK-safe insertion order):
+            {schemaText}
+
+            Foreign key relationships:
+            {fkText}
+
+            Generate the INSERT statements now.
+            """;
+
+        string insertSql;
+        try
+        {
+            var chatClient = new ChatClient("gpt-4o-mini", openAiKey);
+            var response = await chatClient.CompleteChatAsync(
+            [
+                new SystemChatMessage(systemPrompt),
+                new UserChatMessage(userMessage),
+            ]);
+            insertSql = response.Value.Content[0].Text.Trim();
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"[DataGen] OpenAI call failed: {ex.Message}", ex);
+            return new GenerateTestDataOutput { Error = $"AI generation failed: {ex.Message}" };
+        }
+
+        // Execute inside a transaction
+        var insertedCounts = new Dictionary<string, int>();
+        try
+        {
+            await using var conn = new NpgsqlConnection(connectionString);
+            await conn.OpenAsync();
+            await using var tx = await conn.BeginTransactionAsync();
+
+            var statements = insertSql
+                .Split(';', StringSplitOptions.RemoveEmptyEntries | StringSplitOptions.TrimEntries)
+                .Where(s => !string.IsNullOrWhiteSpace(s))
+                .ToList();
+
+            foreach (var stmt in statements)
+            {
+                await using var cmd = new NpgsqlCommand(stmt + ";", conn, tx) { CommandTimeout = 30 };
+                await cmd.ExecuteNonQueryAsync();
+
+                // Track counts per table
+                var lower = stmt.ToLowerInvariant();
+                var intoIdx = lower.IndexOf("into ", StringComparison.Ordinal);
+                if (intoIdx >= 0)
+                {
+                    var afterInto = stmt[(intoIdx + 5)..].TrimStart();
+                    var tableName = afterInto.Split([' ', '('], StringSplitOptions.RemoveEmptyEntries).FirstOrDefault() ?? "unknown";
+                    tableName = tableName.Trim('"');
+                    insertedCounts[tableName] = insertedCounts.GetValueOrDefault(tableName) + 1;
+                }
+            }
+
+            await tx.CommitAsync();
+
+            return new GenerateTestDataOutput { Success = true, InsertedCounts = insertedCounts };
+        }
+        catch (Exception ex)
+        {
+            Logger.Error($"[DataGen] INSERT execution failed: {ex.Message}", ex);
+            return new GenerateTestDataOutput { Error = $"Failed to insert data: {ex.Message}" };
+        }
+    }
+
+    /// <summary>Topologically sorts tables so FK parents come before children.</summary>
+    private static List<SchemaTableDetailDto> TopologicalSort(
+        List<SchemaTableDetailDto> tables,
+        List<SchemaRelationshipDto> relationships)
+    {
+        var names = new HashSet<string>(tables.Select(t => t.Name), StringComparer.OrdinalIgnoreCase);
+        var inDegree = tables.ToDictionary(t => t.Name, _ => 0, StringComparer.OrdinalIgnoreCase);
+        var dependents = tables.ToDictionary(t => t.Name, _ => new List<string>(), StringComparer.OrdinalIgnoreCase);
+
+        foreach (var rel in relationships.Where(r => names.Contains(r.FromTable) && names.Contains(r.ToTable)))
+        {
+            // FromTable depends on ToTable (child -> parent)
+            inDegree[rel.FromTable]++;
+            dependents[rel.ToTable].Add(rel.FromTable);
+        }
+
+        var queue = new Queue<string>(inDegree.Where(kv => kv.Value == 0).Select(kv => kv.Key));
+        var sorted = new List<SchemaTableDetailDto>();
+        var tableMap = tables.ToDictionary(t => t.Name, StringComparer.OrdinalIgnoreCase);
+
+        while (queue.Count > 0)
+        {
+            var name = queue.Dequeue();
+            sorted.Add(tableMap[name]);
+            foreach (var dep in dependents[name])
+            {
+                if (--inDegree[dep] == 0) queue.Enqueue(dep);
+            }
+        }
+
+        // Append any remaining (cycles) at the end
+        foreach (var t in tables.Where(t => !sorted.Any(s => s.Name == t.Name)))
+            sorted.Add(t);
+
+        return sorted;
+    }
+
+    /// <inheritdoc />
     public async Task<AnalyseQueryOutput> AnalyseAsync(AnalyseQueryInput input)
     {
         var connectionString = await GetLocalConnectionStringAsync(input.ConnectionId);

--- a/Frontend/package-lock.json
+++ b/Frontend/package-lock.json
@@ -9,11 +9,13 @@
       "version": "0.1.0",
       "dependencies": {
         "@ant-design/icons": "^6.1.0",
+        "@types/redux-actions": "^2.6.5",
         "antd": "^6.3.4",
         "antd-style": "^4.1.0",
         "next": "16.2.1",
         "react": "19.2.4",
-        "react-dom": "19.2.4"
+        "react-dom": "19.2.4",
+        "redux-actions": "^3.0.3"
       },
       "devDependencies": {
         "@playwright/test": "^1.58.2",
@@ -2287,6 +2289,12 @@
       "peerDependencies": {
         "@types/react": "^19.2.0"
       }
+    },
+    "node_modules/@types/redux-actions": {
+      "version": "2.6.5",
+      "resolved": "https://registry.npmjs.org/@types/redux-actions/-/redux-actions-2.6.5.tgz",
+      "integrity": "sha512-RgXOigay5cNweP+xH1ru+Vaaj1xXYLpWIfSVO8cSA8Ii2xvR+HRfWYdLe1UVOA8X0kIklalGOa0DTDyld0obkg==",
+      "license": "MIT"
     },
     "node_modules/@typescript-eslint/eslint-plugin": {
       "version": "8.57.2",
@@ -5399,6 +5407,12 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/just-curry-it": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/just-curry-it/-/just-curry-it-5.3.0.tgz",
+      "integrity": "sha512-silMIRiFjUWlfaDhkgSzpuAyQ6EX/o09Eu8ZBfmFwQMbax7+LQzeIU2CBrICT6Ne4l86ITCGvUCBpCubWYy0Yw==",
+      "license": "MIT"
+    },
     "node_modules/keyv": {
       "version": "4.5.4",
       "resolved": "https://registry.npmjs.org/keyv/-/keyv-4.5.4.tgz",
@@ -6104,6 +6118,22 @@
       "resolved": "https://registry.npmjs.org/react-is/-/react-is-16.13.1.tgz",
       "integrity": "sha512-24e6ynE2H+OKt4kqsOvNd8kBpV65zoxbA4BVsEOB3ARVWQki/DHzaUoC5KuON/BiccDaCCTZBuOcfZs70kR8bQ==",
       "license": "MIT"
+    },
+    "node_modules/reduce-reducers": {
+      "version": "1.0.4",
+      "resolved": "https://registry.npmjs.org/reduce-reducers/-/reduce-reducers-1.0.4.tgz",
+      "integrity": "sha512-Mb2WZ2bJF597exiqX7owBzrqJ74DHLK3yOQjCyPAaNifRncE8OD0wFIuoMhXxTnHK07+8zZ2SJEKy/qtiyR7vw==",
+      "license": "MIT"
+    },
+    "node_modules/redux-actions": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/redux-actions/-/redux-actions-3.0.3.tgz",
+      "integrity": "sha512-ca+ySXmXWrxDqtauRA6lQtjmRO8Z9Ruog3wbb8wDq4RVW9Y677Nl/AXoJPlxJqH0mpY9QGkg03NkAJwTcyN2pQ==",
+      "license": "MIT",
+      "dependencies": {
+        "just-curry-it": "5.3.0",
+        "reduce-reducers": "1.0.4"
+      }
     },
     "node_modules/reflect.getprototypeof": {
       "version": "1.0.10",

--- a/Frontend/package.json
+++ b/Frontend/package.json
@@ -10,11 +10,13 @@
   },
   "dependencies": {
     "@ant-design/icons": "^6.1.0",
+    "@types/redux-actions": "^2.6.5",
     "antd": "^6.3.4",
     "antd-style": "^4.1.0",
     "next": "16.2.1",
     "react": "19.2.4",
-    "react-dom": "19.2.4"
+    "react-dom": "19.2.4",
+    "redux-actions": "^3.0.3"
   },
   "devDependencies": {
     "@playwright/test": "^1.58.2",

--- a/Frontend/src/app/dashboard/databases/ConnectionCard/ConnectionCard.tsx
+++ b/Frontend/src/app/dashboard/databases/ConnectionCard/ConnectionCard.tsx
@@ -1,8 +1,8 @@
 "use client";
 
 import React from "react";
-import { Button, Tooltip } from "antd";
-import { DatabaseOutlined, EditOutlined, CloudDownloadOutlined, ReloadOutlined } from "@ant-design/icons";
+import { Button, Tag, Tooltip } from "antd";
+import { DatabaseOutlined, EditOutlined, CloudDownloadOutlined, ReloadOutlined, ThunderboltOutlined } from "@ant-design/icons";
 import { useStyles } from "../style/styles";
 
 /** Connection status values for a database card. */
@@ -32,6 +32,8 @@ export interface IDatabase {
     dumpStatus: number;
     /** Raw restore status enum value (0=None,1=Pending,2=InProgress,3=Completed,4=Failed). */
     restoreStatusRaw: number;
+    /** Whether this connection was configured to dump schema only (no row data). */
+    schemaOnly: boolean;
 }
 
 interface IConnectionCardProps {
@@ -39,12 +41,13 @@ interface IConnectionCardProps {
     onEdit: () => void;
     onDump: () => void;
     onRebuild: () => void;
+    onGenerateData: () => void;
     isDumping: boolean;
     isRebuilding: boolean;
 }
 
 /** Card displaying a single database connection's metadata and status. */
-const ConnectionCard: React.FC<IConnectionCardProps> = ({ database, onEdit, onDump, onRebuild, isDumping, isRebuilding }) => {
+const ConnectionCard: React.FC<IConnectionCardProps> = ({ database, onEdit, onDump, onRebuild, onGenerateData, isDumping, isRebuilding }) => {
     const { styles } = useStyles();
 
     const dumpBusy = isDumping || database.dumpStatus === 1 || database.dumpStatus === 2;
@@ -79,6 +82,7 @@ const ConnectionCard: React.FC<IConnectionCardProps> = ({ database, onEdit, onDu
                 <span className={database.isLocalReady ? styles.badgeConnected : styles.badgeDisconnected}>
                     {database.restoreStatus}
                 </span>
+                {database.schemaOnly && <Tag color="blue">Schema Only</Tag>}
             </div>
             <div className={styles.cardActions}>
                 <Tooltip title="Dump — capture a fresh snapshot from the live database">
@@ -103,6 +107,17 @@ const ConnectionCard: React.FC<IConnectionCardProps> = ({ database, onEdit, onDu
                         Rebuild
                     </Button>
                 </Tooltip>
+                {database.schemaOnly && database.isLocalReady && (
+                    <Tooltip title="Browse tables and generate AI test data for this schema-only database">
+                        <Button
+                            size="small"
+                            icon={<ThunderboltOutlined />}
+                            onClick={onGenerateData}
+                        >
+                            Generate Data
+                        </Button>
+                    </Tooltip>
+                )}
                 <Button type="text" size="small" icon={<EditOutlined />} onClick={onEdit}>Edit</Button>
             </div>
         </div>

--- a/Frontend/src/app/dashboard/databases/ConnectionCardList/ConnectionCardList.tsx
+++ b/Frontend/src/app/dashboard/databases/ConnectionCardList/ConnectionCardList.tsx
@@ -11,12 +11,13 @@ interface IConnectionCardListProps {
     onEdit: (id: string) => void;
     onDump: (id: string) => void;
     onRebuild: (id: string) => void;
+    onGenerateData: (id: string) => void;
     dumpingIds: Set<string>;
     rebuildingIds: Set<string>;
 }
 
 /** Grid of all registered database connection cards. */
-const ConnectionCardList: React.FC<IConnectionCardListProps> = ({ databases, isLoading, onEdit, onDump, onRebuild, dumpingIds, rebuildingIds }) => {
+const ConnectionCardList: React.FC<IConnectionCardListProps> = ({ databases, isLoading, onEdit, onDump, onRebuild, onGenerateData, dumpingIds, rebuildingIds }) => {
     const { styles } = useStyles();
 
     if (isLoading) {
@@ -42,6 +43,7 @@ const ConnectionCardList: React.FC<IConnectionCardListProps> = ({ databases, isL
                     onEdit={() => onEdit(database.id)}
                     onDump={() => onDump(database.id)}
                     onRebuild={() => onRebuild(database.id)}
+                    onGenerateData={() => onGenerateData(database.id)}
                     isDumping={dumpingIds.has(database.id)}
                     isRebuilding={rebuildingIds.has(database.id)}
                 />

--- a/Frontend/src/app/dashboard/databases/DataGeneratorDrawer/DataGeneratorDrawer.tsx
+++ b/Frontend/src/app/dashboard/databases/DataGeneratorDrawer/DataGeneratorDrawer.tsx
@@ -1,0 +1,197 @@
+"use client";
+
+import React, { useEffect, useState } from "react";
+import { Alert, Button, Collapse, Drawer, InputNumber, Spin, Table, Tag, Typography } from "antd";
+import { KeyOutlined, LinkOutlined } from "@ant-design/icons";
+import {
+    ISchemaColumn,
+    ISchemaWithRelationships,
+    getSchemaWithRelationships,
+    generateTestData,
+} from "@/services/queryService";
+
+const { Text } = Typography;
+
+interface IDataGeneratorDrawerProps {
+    connectionId: string | null;
+    connectionName: string;
+    onClose: () => void;
+}
+
+const DataGeneratorDrawer: React.FC<IDataGeneratorDrawerProps> = ({ connectionId, connectionName, onClose }) => {
+    const [schema, setSchema] = useState<ISchemaWithRelationships | null>(null);
+    const [isLoadingSchema, setIsLoadingSchema] = useState(false);
+    const [schemaError, setSchemaError] = useState<string | null>(null);
+    const [rowCounts, setRowCounts] = useState<Record<string, number>>({});
+    const [isGenerating, setIsGenerating] = useState(false);
+    const [generateResult, setGenerateResult] = useState<{ success: boolean; counts: Record<string, number>; error: string | null } | null>(null);
+
+    useEffect(() => {
+        if (!connectionId) return;
+        setSchema(null);
+        setSchemaError(null);
+        setGenerateResult(null);
+        setIsLoadingSchema(true);
+
+        getSchemaWithRelationships(connectionId)
+            .then((data) => {
+                setSchema(data);
+                const defaults: Record<string, number> = {};
+                data.tables.forEach((t) => { defaults[t.name] = 10; });
+                setRowCounts(defaults);
+            })
+            .catch((err: unknown) => {
+                setSchemaError(err instanceof Error ? err.message : "Failed to load schema.");
+            })
+            .finally(() => setIsLoadingSchema(false));
+    }, [connectionId]);
+
+    const handleGenerate = async (): Promise<void> => {
+        if (!connectionId || !schema) return;
+        setIsGenerating(true);
+        setGenerateResult(null);
+        try {
+            const result = await generateTestData({
+                connectionId,
+                tables: schema.tables.map((t) => ({ tableName: t.name, rowCount: rowCounts[t.name] ?? 10 })),
+            });
+            setGenerateResult({ success: result.success, counts: result.insertedCounts ?? {}, error: result.error ?? null });
+        } catch (err: unknown) {
+            setGenerateResult({ success: false, counts: {}, error: err instanceof Error ? err.message : "Unexpected error." });
+        } finally {
+            setIsGenerating(false);
+        }
+    };
+
+    const columnDefs = [
+        {
+            title: "Column",
+            dataIndex: "name",
+            key: "name",
+            render: (name: string, col: ISchemaColumn) => (
+                <span>
+                    {col.isPrimaryKey && <KeyOutlined style={{ color: "var(--ant-color-warning)", marginRight: 4 }} />}
+                    {col.referencesTable && <LinkOutlined style={{ color: "var(--ant-color-primary)", marginRight: 4 }} />}
+                    {name}
+                </span>
+            ),
+        },
+        {
+            title: "Type",
+            dataIndex: "dataType",
+            key: "dataType",
+            render: (t: string) => <Text code>{t}</Text>,
+        },
+        {
+            title: "Nullable",
+            dataIndex: "isNullable",
+            key: "isNullable",
+            render: (v: boolean) => v ? <Tag color="default">NULL</Tag> : <Tag color="red">NOT NULL</Tag>,
+        },
+        {
+            title: "References",
+            key: "ref",
+            render: (_: unknown, col: ISchemaColumn) =>
+                col.referencesTable
+                    ? <Text type="secondary">{col.referencesTable}.{col.referencesColumn}</Text>
+                    : null,
+        },
+    ];
+
+    return (
+        <Drawer
+            title={`Generate Data — ${connectionName}`}
+            width={720}
+            open={!!connectionId}
+            onClose={onClose}
+            footer={
+                <div style={{ display: "flex", justifyContent: "flex-end", gap: 8 }}>
+                    <Button onClick={onClose}>Cancel</Button>
+                    <Button
+                        type="primary"
+                        loading={isGenerating}
+                        disabled={!schema || isLoadingSchema}
+                        onClick={() => void handleGenerate()}
+                    >
+                        Generate
+                    </Button>
+                </div>
+            }
+        >
+            {isLoadingSchema && (
+                <div style={{ textAlign: "center", padding: 48 }}>
+                    <Spin size="large" />
+                    <p style={{ marginTop: 12, color: "var(--ant-color-text-secondary)" }}>Loading schema…</p>
+                </div>
+            )}
+
+            {schemaError && <Alert type="error" message={schemaError} style={{ marginBottom: 16 }} />}
+
+            {generateResult && (
+                <Alert
+                    type={generateResult.success ? "success" : "error"}
+                    message={generateResult.success ? "Data generated successfully" : "Generation failed"}
+                    description={
+                        generateResult.success
+                            ? Object.entries(generateResult.counts).map(([t, n]) => `${t}: ${n} row(s)`).join(" · ") || "No rows counted."
+                            : generateResult.error
+                    }
+                    showIcon
+                    closable
+                    style={{ marginBottom: 16 }}
+                />
+            )}
+
+            {schema && (
+                <>
+                    {schema.relationships.length > 0 && (
+                        <div style={{ marginBottom: 16 }}>
+                            <Text strong>Relationships</Text>
+                            <div style={{ marginTop: 8, display: "flex", flexWrap: "wrap", gap: 6 }}>
+                                {schema.relationships.map((r, i) => (
+                                    <Tag key={i} color="blue">
+                                        {r.fromTable}.{r.fromColumn} → {r.toTable}.{r.toColumn}
+                                    </Tag>
+                                ))}
+                            </div>
+                        </div>
+                    )}
+
+                    <Collapse
+                        size="small"
+                        items={schema.tables.map((table) => ({
+                            key: table.name,
+                            label: (
+                                <div style={{ display: "flex", alignItems: "center", justifyContent: "space-between" }}>
+                                    <Text strong>{table.name}</Text>
+                                    <div style={{ display: "flex", alignItems: "center", gap: 8 }} onClick={(e) => e.stopPropagation()}>
+                                        <Text type="secondary" style={{ fontSize: 12 }}>Rows:</Text>
+                                        <InputNumber
+                                            size="small"
+                                            min={1}
+                                            max={1000}
+                                            value={rowCounts[table.name] ?? 10}
+                                            onChange={(v) => setRowCounts((prev) => ({ ...prev, [table.name]: v ?? 10 }))}
+                                            style={{ width: 70 }}
+                                        />
+                                    </div>
+                                </div>
+                            ),
+                            children: (
+                                <Table<ISchemaColumn>
+                                    dataSource={table.columns}
+                                    columns={columnDefs}
+                                    rowKey="name"
+                                    size="small"
+                                    pagination={false}
+                                />
+                            ),
+                        }))}
+                    />
+                </>
+            )}
+        </Drawer>
+    );
+};
+
+export default DataGeneratorDrawer;

--- a/Frontend/src/app/dashboard/databases/page.tsx
+++ b/Frontend/src/app/dashboard/databases/page.tsx
@@ -6,17 +6,11 @@ import DatabasesHeader from "./DatabasesHeader/DatabasesHeader";
 import ConnectionCardList from "./ConnectionCardList/ConnectionCardList";
 import AddConnectionForm from "./AddConnectionForm/AddConnectionForm";
 import EditConnectionModal from "./EditConnectionModal/EditConnectionModal";
-import {
-    getDatabaseConnections,
-    IDatabaseConnectionDto,
-    DATABASE_ENGINE_NAMES,
-    RESTORE_STATUS_LABELS,
-    triggerDump,
-    triggerRestore,
-} from "@/services/databaseConnectionService";
+import DataGeneratorDrawer from "./DataGeneratorDrawer/DataGeneratorDrawer";
+import { IDatabaseConnectionDto, DATABASE_ENGINE_NAMES, RESTORE_STATUS_LABELS } from "@/services/databaseConnectionService";
+import { useDatabaseConnectionState, useDatabaseConnectionActions } from "@/providers/databaseConnection";
 import { IDatabase } from "./ConnectionCard/ConnectionCard";
 
-/** Maps a backend DTO to the shape expected by ConnectionCard. */
 function mapToDatabase(dto: IDatabaseConnectionDto): IDatabase {
     return {
         id: dto.id,
@@ -30,10 +24,10 @@ function mapToDatabase(dto: IDatabaseConnectionDto): IDatabase {
         isLocalReady: dto.restoreStatus === 3,
         dumpStatus: dto.dumpStatus,
         restoreStatusRaw: dto.restoreStatus,
+        schemaOnly: dto.schemaOnly,
     };
 }
 
-/** Returns true if any connection has a pending or in-progress dump or restore. */
 function hasActiveOperation(items: IDatabaseConnectionDto[]): boolean {
     return items.some((c) =>
         c.dumpStatus === 1 || c.dumpStatus === 2 ||
@@ -41,55 +35,47 @@ function hasActiveOperation(items: IDatabaseConnectionDto[]): boolean {
     );
 }
 
-/** Databases page — view registered connections and add new ones. */
 export default function DatabasesPage(): React.JSX.Element {
-    const [rawConnections, setRawConnections] = useState<IDatabaseConnectionDto[]>([]);
-    const [databases, setDatabases] = useState<IDatabase[]>([]);
-    const [isLoading, setIsLoading] = useState<boolean>(true);
+    const { connections, isPending } = useDatabaseConnectionState();
+    const { getConnections, triggerDump, triggerRestore } = useDatabaseConnectionActions();
+
     const [editingConnection, setEditingConnection] = useState<IDatabaseConnectionDto | null>(null);
+    const [dataGenConnectionId, setDataGenConnectionId] = useState<string | null>(null);
     const [dumpingIds, setDumpingIds] = useState<Set<string>>(new Set());
     const [rebuildingIds, setRebuildingIds] = useState<Set<string>>(new Set());
     const pollTimerRef = useRef<ReturnType<typeof setInterval> | null>(null);
 
-    const fetchConnections = useCallback(async (): Promise<IDatabaseConnectionDto[]> => {
-        const items = await getDatabaseConnections();
-        setRawConnections(items);
-        setDatabases(items.map(mapToDatabase));
-        return items;
-    }, []);
-
     const startPolling = useCallback(() => {
         if (pollTimerRef.current) return;
-        pollTimerRef.current = setInterval(async () => {
-            const items = await fetchConnections();
-            if (!hasActiveOperation(items)) {
+        pollTimerRef.current = setInterval(() => {
+            void getConnections();
+            if (!hasActiveOperation(connections)) {
                 clearInterval(pollTimerRef.current!);
                 pollTimerRef.current = null;
             }
         }, 3000);
-    }, [fetchConnections]);
+    }, [getConnections, connections]);
 
     useEffect(() => {
-        setIsLoading(true);
-        fetchConnections()
-            .then((items) => {
-                if (hasActiveOperation(items)) startPolling();
-            })
-            .finally(() => setIsLoading(false));
-
+        void getConnections();
         return () => {
             if (pollTimerRef.current) clearInterval(pollTimerRef.current);
         };
-    }, [fetchConnections, startPolling]);
+    }, [getConnections]);
+
+    useEffect(() => {
+        if (hasActiveOperation(connections)) {
+            startPolling();
+        }
+    }, [connections, startPolling]);
 
     const handleEdit = (id: string): void => {
-        const connection = rawConnections.find((c) => c.id === id) ?? null;
-        setEditingConnection(connection);
+        setEditingConnection(connections.find((c) => c.id === id) ?? null);
     };
 
     const handleEditSaved = (): void => {
         setEditingConnection(null);
-        void fetchConnections().then(startPolling);
+        void getConnections();
     };
 
     const handleDump = async (id: string): Promise<void> => {
@@ -97,10 +83,9 @@ export default function DatabasesPage(): React.JSX.Element {
         try {
             await triggerDump(id);
             void message.success("Dump queued — the snapshot will be ready shortly.");
-            await fetchConnections();
             startPolling();
-        } catch (err) {
-            void message.error(err instanceof Error ? err.message : "Failed to trigger dump.");
+        } catch {
+            void message.error("Failed to trigger dump.");
         } finally {
             setDumpingIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
         }
@@ -111,10 +96,9 @@ export default function DatabasesPage(): React.JSX.Element {
         try {
             await triggerRestore(id);
             void message.success("Rebuild queued — the local copy will be ready shortly.");
-            await fetchConnections();
             startPolling();
-        } catch (err) {
-            void message.error(err instanceof Error ? err.message : "Failed to trigger rebuild.");
+        } catch {
+            void message.error("Failed to trigger rebuild.");
         } finally {
             setRebuildingIds((prev) => { const next = new Set(prev); next.delete(id); return next; });
         }
@@ -124,19 +108,25 @@ export default function DatabasesPage(): React.JSX.Element {
         <>
             <DatabasesHeader />
             <ConnectionCardList
-                databases={databases}
-                isLoading={isLoading}
+                databases={connections.map(mapToDatabase)}
+                isLoading={isPending && connections.length === 0}
                 onEdit={handleEdit}
                 onDump={handleDump}
                 onRebuild={handleRebuild}
+                onGenerateData={(id) => setDataGenConnectionId(id)}
                 dumpingIds={dumpingIds}
                 rebuildingIds={rebuildingIds}
             />
-            <AddConnectionForm onSaved={() => void fetchConnections()} />
+            <AddConnectionForm onSaved={() => void getConnections()} />
             <EditConnectionModal
                 connection={editingConnection}
                 onClose={() => setEditingConnection(null)}
                 onSaved={handleEditSaved}
+            />
+            <DataGeneratorDrawer
+                connectionId={dataGenConnectionId}
+                connectionName={connections.find((c) => c.id === dataGenConnectionId)?.name ?? ""}
+                onClose={() => setDataGenConnectionId(null)}
             />
         </>
     );

--- a/Frontend/src/app/dashboard/history/page.tsx
+++ b/Frontend/src/app/dashboard/history/page.tsx
@@ -5,10 +5,10 @@ import { Spin } from "antd";
 import HistoryHeader from "./HistoryHeader/HistoryHeader";
 import HistoryTable from "./HistoryTable/HistoryTable";
 import HistoryPagination from "./HistoryPagination/HistoryPagination";
-import { getAllQueryHistory, IQueryHistoryDto } from "@/services/queryHistoryService";
-import { getDatabaseConnections, IDatabaseConnectionDto } from "@/services/databaseConnectionService";
+import { IQueryHistoryDto } from "@/services/queryHistoryService";
+import { useDatabaseConnectionState, useDatabaseConnectionActions } from "@/providers/databaseConnection";
+import { useQueryHistoryState, useQueryHistoryActions } from "@/providers/queryHistory";
 
-/** Status of a historical analysis entry. */
 type HistoryStatus = "success" | "warning" | "critical";
 
 interface IHistoryEntry {
@@ -25,20 +25,14 @@ const PAGE_SIZE = 6;
 function toHistoryEntry(dto: IQueryHistoryDto, connectionMap: Map<string, string>): IHistoryEntry {
     const connectionName = connectionMap.get(dto.databaseConnectionId) ?? dto.databaseConnectionId.slice(0, 8);
     const status: HistoryStatus = dto.errorMessage ? "critical" : dto.suggestedQuery ? "warning" : "success";
-    const improvement = dto.suggestedQuery ? "Has suggestion" : null;
     const date = new Date(dto.creationTime).toLocaleString([], {
-        year: "numeric",
-        month: "2-digit",
-        day: "2-digit",
-        hour: "2-digit",
-        minute: "2-digit",
+        year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit",
     });
-
     return {
         id: dto.id.slice(0, 8).toUpperCase(),
         queryPreview: dto.queryText,
         database: connectionName,
-        improvement,
+        improvement: dto.suggestedQuery ? "Has suggestion" : null,
         status,
         date,
     };
@@ -46,46 +40,29 @@ function toHistoryEntry(dto: IQueryHistoryDto, connectionMap: Map<string, string
 
 /** Analysis History page — paginated log of all query executions run across the team. */
 export default function HistoryPage(): React.JSX.Element {
-    const [entries, setEntries] = useState<IHistoryEntry[]>([]);
-    const [isLoading, setIsLoading] = useState(true);
+    const { connections } = useDatabaseConnectionState();
+    const { getConnections } = useDatabaseConnectionActions();
+    const { entries, isPending } = useQueryHistoryState();
+    const { getAllHistory } = useQueryHistoryActions();
+
     const [currentPage, setCurrentPage] = useState<number>(1);
 
     useEffect(() => {
-        void (async () => {
-            setIsLoading(true);
-            try {
-                const [historyDtos, connections] = await Promise.all([
-                    getAllQueryHistory(),
-                    getDatabaseConnections(),
-                ]);
+        void getConnections();
+        void getAllHistory();
+    }, [getConnections, getAllHistory]);
 
-                const connectionMap = new Map<string, string>(
-                    connections.map((c: IDatabaseConnectionDto) => [c.id, c.name])
-                );
+    const connectionMap = new Map<string, string>(connections.map((c) => [c.id, c.name]));
+    const mappedEntries = entries.map((dto) => toHistoryEntry(dto, connectionMap));
 
-                setEntries(historyDtos.map((dto) => toHistoryEntry(dto, connectionMap)));
-            } finally {
-                setIsLoading(false);
-            }
-        })();
-    }, []);
-
-    const totalEntries = entries.length;
+    const totalEntries = mappedEntries.length;
     const totalPages = Math.max(1, Math.ceil(totalEntries / PAGE_SIZE));
     const safePage = Math.min(currentPage, totalPages);
     const rangeStart = totalEntries === 0 ? 0 : (safePage - 1) * PAGE_SIZE + 1;
     const rangeEnd = Math.min(safePage * PAGE_SIZE, totalEntries);
-    const pageEntries = entries.slice(rangeStart - 1, rangeEnd);
+    const pageEntries = mappedEntries.slice(rangeStart - 1, rangeEnd);
 
-    const handleFilter = (): void => {
-        // todo: open filter drawer/modal
-    };
-
-    const handleExportCsv = (): void => {
-        // todo: trigger CSV export via backend API
-    };
-
-    if (isLoading) {
+    if (isPending && entries.length === 0) {
         return (
             <div style={{ display: "flex", justifyContent: "center", paddingTop: 80 }}>
                 <Spin size="large" />
@@ -95,7 +72,7 @@ export default function HistoryPage(): React.JSX.Element {
 
     return (
         <>
-            <HistoryHeader onFilter={handleFilter} onExportCsv={handleExportCsv} />
+            <HistoryHeader onFilter={() => {}} onExportCsv={() => {}} />
             <HistoryTable entries={pageEntries} />
             <HistoryPagination
                 rangeStart={rangeStart}

--- a/Frontend/src/app/dashboard/layout.tsx
+++ b/Frontend/src/app/dashboard/layout.tsx
@@ -1,9 +1,19 @@
+import React from "react";
 import DashboardLayout from "./DashboardLayout/DashboardLayout";
+import { DatabaseConnectionProvider } from "@/providers/databaseConnection";
+import { QueryHistoryProvider } from "@/providers/queryHistory";
+import { SchemaAdvisorHistoryProvider } from "@/providers/schemaAdvisorHistory";
 
 export default function Layout({ children }: { children: React.ReactNode }): React.JSX.Element {
     return (
-        <DashboardLayout>
-            {children}
-        </DashboardLayout>
+        <DatabaseConnectionProvider>
+            <QueryHistoryProvider>
+                <SchemaAdvisorHistoryProvider>
+                    <DashboardLayout>
+                        {children}
+                    </DashboardLayout>
+                </SchemaAdvisorHistoryProvider>
+            </QueryHistoryProvider>
+        </DatabaseConnectionProvider>
     );
 }

--- a/Frontend/src/app/dashboard/playground/page.tsx
+++ b/Frontend/src/app/dashboard/playground/page.tsx
@@ -8,13 +8,8 @@ import ExecutionInfoPanel from "./ExecutionInfoPanel/ExecutionInfoPanel";
 import HistoryPanel from "./HistoryPanel/HistoryPanel";
 import { useStyles } from "./style/styles";
 import { executeQuery, getSchema, ISchemaTable } from "@/services/queryService";
-import { getDatabaseConnections, IDatabaseConnectionDto } from "@/services/databaseConnectionService";
-import {
-    getQueryHistory,
-    addQueryHistory,
-    deleteQueryHistory,
-    IQueryHistoryDto,
-} from "@/services/queryHistoryService";
+import { useDatabaseConnectionState, useDatabaseConnectionActions } from "@/providers/databaseConnection";
+import { useQueryHistoryState, useQueryHistoryActions } from "@/providers/queryHistory";
 
 interface IQueryResult {
     columns: string[];
@@ -29,15 +24,9 @@ interface IExecutionInfo {
     queryPlan: string | null;
 }
 
-const IDLE_EXECUTION_INFO: IExecutionInfo = {
-    status: "idle",
-    executionTimeMs: null,
-    queryPlan: null,
-};
+const IDLE_EXECUTION_INFO: IExecutionInfo = { status: "idle", executionTimeMs: null, queryPlan: null };
+const DEFAULT_SQL = "";
 
-const DEFAULT_SQL = "SELECT * FROM ";
-
-/** Converts milliseconds to a .NET TimeSpan string (HH:MM:SS.fffffff). */
 function msToTimeSpan(ms: number): string {
     const totalSeconds = Math.floor(ms / 1000);
     const h = Math.floor(totalSeconds / 3600).toString().padStart(2, "0");
@@ -51,33 +40,33 @@ function msToTimeSpan(ms: number): string {
 export default function PlaygroundPage(): React.JSX.Element {
     const { styles } = useStyles();
 
-    const [connections, setConnections] = useState<IDatabaseConnectionDto[]>([]);
-    const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
+    const { connections, selectedConnectionId } = useDatabaseConnectionState();
+    const { getConnections, setSelectedConnectionId } = useDatabaseConnectionActions();
+    const { entries: history, isPending: isLoadingHistory } = useQueryHistoryState();
+    const { getHistoryByConnection, addEntry, deleteEntry } = useQueryHistoryActions();
+
+    const restoredConnections = connections.filter((c) => c.restoreStatus === 3);
+
     const [schemaTables, setSchemaTables] = useState<ISchemaTable[]>([]);
     const [isLoadingSchema, setIsLoadingSchema] = useState(false);
     const [schemaError, setSchemaError] = useState<string | null>(null);
-
     const [sqlText, setSqlText] = useState<string>(DEFAULT_SQL);
     const [queryResult, setQueryResult] = useState<IQueryResult | null>(null);
     const [executionInfo, setExecutionInfo] = useState<IExecutionInfo>(IDLE_EXECUTION_INFO);
     const [queryError, setQueryError] = useState<string | null>(null);
     const [isRunning, setIsRunning] = useState<boolean>(false);
 
-    const [history, setHistory] = useState<IQueryHistoryDto[]>([]);
-    const [isLoadingHistory, setIsLoadingHistory] = useState(false);
-
-    // Load restored connections on mount
     useEffect(() => {
-        void getDatabaseConnections().then((items) => {
-            const restored = items.filter((c) => c.restoreStatus === 3);
-            setConnections(restored);
-            if (restored.length === 1) {
-                setSelectedConnectionId(restored[0].id);
-            }
-        });
-    }, []);
+        void getConnections();
+    }, [getConnections]);
 
-    // Reload schema when connection changes
+    useEffect(() => {
+        if (restoredConnections.length === 1 && !selectedConnectionId) {
+            setSelectedConnectionId(restoredConnections[0].id);
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [connections]);
+
     const loadSchema = useCallback(async (connectionId: string): Promise<void> => {
         setIsLoadingSchema(true);
         setSchemaError(null);
@@ -92,28 +81,14 @@ export default function PlaygroundPage(): React.JSX.Element {
         }
     }, []);
 
-    // Reload history when connection changes
-    const loadHistory = useCallback(async (connectionId: string): Promise<void> => {
-        setIsLoadingHistory(true);
-        try {
-            const entries = await getQueryHistory(connectionId);
-            setHistory(entries);
-        } catch {
-            setHistory([]);
-        } finally {
-            setIsLoadingHistory(false);
-        }
-    }, []);
-
     useEffect(() => {
         if (selectedConnectionId) {
             void loadSchema(selectedConnectionId);
-            void loadHistory(selectedConnectionId);
+            void getHistoryByConnection(selectedConnectionId);
         } else {
             setSchemaTables([]);
-            setHistory([]);
         }
-    }, [selectedConnectionId, loadSchema, loadHistory]);
+    }, [selectedConnectionId, loadSchema, getHistoryByConnection]);
 
     const handleRun = async (): Promise<void> => {
         if (!sqlText.trim() || !selectedConnectionId) return;
@@ -123,65 +98,37 @@ export default function PlaygroundPage(): React.JSX.Element {
         setQueryError(null);
         setExecutionInfo(IDLE_EXECUTION_INFO);
 
-        const result = await executeQuery({ connectionId: selectedConnectionId, sql: sqlText });
+        try {
+            const result = await executeQuery({ connectionId: selectedConnectionId, sql: sqlText });
 
-        setIsRunning(false);
-
-        if (result.error) {
-            setQueryError(result.error);
+            if (result.error) {
+                setQueryError(result.error);
+                setExecutionInfo({ status: "error", executionTimeMs: null, queryPlan: null });
+                void addEntry({
+                    databaseConnectionId: selectedConnectionId,
+                    queryText: sqlText,
+                    errorMessage: result.error,
+                    executionTime: "00:00:00.0000000",
+                });
+            } else {
+                setQueryResult({ columns: result.columns, rows: result.rows, rowCount: result.rowsAffected, executionTimeMs: result.executionTimeMs });
+                setExecutionInfo({ status: "success", executionTimeMs: result.executionTimeMs, queryPlan: null });
+                void addEntry({
+                    databaseConnectionId: selectedConnectionId,
+                    queryText: sqlText,
+                    resultSummary: `${result.rowsAffected} rows`,
+                    executionTime: msToTimeSpan(result.executionTimeMs),
+                });
+            }
+        } catch (error) {
+            setQueryError(error instanceof Error ? error.message : "An unexpected error occurred.");
             setExecutionInfo({ status: "error", executionTimeMs: null, queryPlan: null });
-
-            void addQueryHistory({
-                databaseConnectionId: selectedConnectionId,
-                queryText: sqlText,
-                errorMessage: result.error,
-                executionTime: "00:00:00.0000000",
-            }).then(() => void loadHistory(selectedConnectionId));
-        } else {
-            setQueryResult({
-                columns: result.columns,
-                rows: result.rows,
-                rowCount: result.rowsAffected,
-                executionTimeMs: result.executionTimeMs,
-            });
-            setExecutionInfo({
-                status: "success",
-                executionTimeMs: result.executionTimeMs,
-                queryPlan: null,
-            });
-
-            void addQueryHistory({
-                databaseConnectionId: selectedConnectionId,
-                queryText: sqlText,
-                resultSummary: `${result.rowsAffected} rows`,
-                executionTime: msToTimeSpan(result.executionTimeMs),
-            }).then(() => void loadHistory(selectedConnectionId));
+        } finally {
+            setIsRunning(false);
         }
     };
 
-    const handleExplain = (): void => {
-        // todo: call backend explain API
-    };
-
-    const handleAiAnalyse = (): void => {
-        // todo: call backend AI analysis API
-    };
-
-    const handleHistorySelect = (query: string): void => {
-        setSqlText(query);
-    };
-
-    const handleHistoryDelete = async (entryId: string): Promise<void> => {
-        await deleteQueryHistory(entryId);
-        if (selectedConnectionId) {
-            void loadHistory(selectedConnectionId);
-        }
-    };
-
-    const connectionOptions = connections.map((c) => ({
-        value: c.id,
-        label: c.name,
-    }));
+    const connectionOptions = restoredConnections.map((c) => ({ value: c.id, label: c.name }));
 
     return (
         <>
@@ -216,8 +163,8 @@ export default function PlaygroundPage(): React.JSX.Element {
                     sqlText={sqlText}
                     onSqlChange={setSqlText}
                     onRun={() => void handleRun()}
-                    onExplain={handleExplain}
-                    onAiAnalyse={handleAiAnalyse}
+                    onExplain={() => {}}
+                    onAiAnalyse={() => {}}
                     isRunning={isRunning}
                     queryResult={queryResult}
                 />
@@ -228,8 +175,8 @@ export default function PlaygroundPage(): React.JSX.Element {
                     history={history}
                     isLoading={isLoadingHistory}
                     hasConnection={!!selectedConnectionId}
-                    onSelect={handleHistorySelect}
-                    onDelete={(id) => void handleHistoryDelete(id)}
+                    onSelect={(query) => setSqlText(query)}
+                    onDelete={(id) => void deleteEntry(id)}
                 />
             </div>
         </>

--- a/Frontend/src/app/dashboard/query-analysis/page.tsx
+++ b/Frontend/src/app/dashboard/query-analysis/page.tsx
@@ -7,78 +7,66 @@ import QueryEditorPanel from "./QueryEditorPanel/QueryEditorPanel";
 import ResultsPanel from "./ResultsPanel/ResultsPanel";
 import { useStyles } from "./style/styles";
 import { analyseQuery, benchmarkQuery, IBenchmarkResponse, IAnalyseQueryResponse } from "@/services/queryService";
-import { getDatabaseConnections, IDatabaseConnectionDto } from "@/services/databaseConnectionService";
+import { useDatabaseConnectionState, useDatabaseConnectionActions } from "@/providers/databaseConnection";
 
 /** Query Analysis page — paste SQL, trigger analysis, view optimisation results. */
 export default function QueryAnalysisPage(): React.JSX.Element {
     const { styles } = useStyles();
 
-    const [connections, setConnections] = useState<IDatabaseConnectionDto[]>([]);
-    const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
+    const { connections, selectedConnectionId } = useDatabaseConnectionState();
+    const { getConnections, setSelectedConnectionId } = useDatabaseConnectionActions();
+
+    const restoredConnections = connections.filter((c) => c.restoreStatus === 3);
 
     const [sqlText, setSqlText] = useState<string>("");
     const [intentText, setIntentText] = useState<string>("");
     const [isAnalysing, setIsAnalysing] = useState<boolean>(false);
     const [analysisResult, setAnalysisResult] = useState<IAnalyseQueryResponse | null>(null);
     const [analyseError, setAnalyseError] = useState<string | null>(null);
-
     const [isBenchmarking, setIsBenchmarking] = useState<boolean>(false);
     const [benchmarkResult, setBenchmarkResult] = useState<IBenchmarkResponse | null>(null);
     const [benchmarkError, setBenchmarkError] = useState<string | null>(null);
 
     useEffect(() => {
-        void getDatabaseConnections().then((items) => {
-            const restored = items.filter((c) => c.restoreStatus === 3);
-            setConnections(restored);
-            if (restored.length === 1) setSelectedConnectionId(restored[0].id);
-        });
-    }, []);
+        void getConnections();
+    }, [getConnections]);
+
+    useEffect(() => {
+        if (restoredConnections.length === 1 && !selectedConnectionId) {
+            setSelectedConnectionId(restoredConnections[0].id);
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [connections]);
 
     const handleAnalyse = async (): Promise<void> => {
         if (!sqlText.trim() || !selectedConnectionId) return;
-
         setIsAnalysing(true);
         setAnalysisResult(null);
         setAnalyseError(null);
-
-        const result = await analyseQuery({
-            connectionId: selectedConnectionId,
-            sql: sqlText,
-            intent: intentText || undefined,
-        });
-
-        setIsAnalysing(false);
-
-        if (result.error) {
-            setAnalyseError(result.error);
-        } else {
-            setAnalysisResult(result);
+        try {
+            const result = await analyseQuery({ connectionId: selectedConnectionId, sql: sqlText, intent: intentText || undefined });
+            if (result.error) setAnalyseError(result.error);
+            else setAnalysisResult(result);
+        } catch (error) {
+            setAnalyseError(error instanceof Error ? error.message : "An unexpected error occurred.");
+        } finally {
+            setIsAnalysing(false);
         }
-    };
-
-    const handleFormat = (): void => {
-        // todo: format SQL via backend or local formatter
     };
 
     const handleBenchmark = async (): Promise<void> => {
         if (!selectedConnectionId || !sqlText.trim() || !analysisResult?.suggestedQuery) return;
-
         setIsBenchmarking(true);
         setBenchmarkResult(null);
         setBenchmarkError(null);
-
-        const result = await benchmarkQuery({
-            connectionId: selectedConnectionId,
-            originalSql: sqlText,
-            suggestedSql: analysisResult.suggestedQuery,
-        });
-
-        setIsBenchmarking(false);
-
-        if (result.error) {
-            setBenchmarkError(result.error);
-        } else {
-            setBenchmarkResult(result);
+        try {
+            const result = await benchmarkQuery({ connectionId: selectedConnectionId, originalSql: sqlText, suggestedSql: analysisResult.suggestedQuery });
+            if (result.error) setBenchmarkError(result.error);
+            else setBenchmarkResult(result);
+        } catch (error) {
+            setBenchmarkError(error instanceof Error ? error.message : "An unexpected error occurred.");
+        } finally {
+            setIsBenchmarking(false);
         }
     };
 
@@ -91,9 +79,8 @@ export default function QueryAnalysisPage(): React.JSX.Element {
         setBenchmarkError(null);
     };
 
-    const selectedConnection = connections.find((c) => c.id === selectedConnectionId) ?? null;
-    const connectionOptions = connections.map((c) => ({ value: c.id, label: c.name }));
-    const hasResults = analysisResult !== null;
+    const selectedConnection = restoredConnections.find((c) => c.id === selectedConnectionId) ?? null;
+    const connectionOptions = restoredConnections.map((c) => ({ value: c.id, label: c.name }));
 
     return (
         <>
@@ -115,13 +102,13 @@ export default function QueryAnalysisPage(): React.JSX.Element {
                     onSqlChange={setSqlText}
                     intentText={intentText}
                     onIntentChange={setIntentText}
-                    onFormat={handleFormat}
+                    onFormat={() => {}}
                     onClear={handleClear}
                     connectionName={selectedConnection?.name ?? null}
                 />
                 <ResultsPanel
                     isAnalysing={isAnalysing}
-                    hasResults={hasResults}
+                    hasResults={analysisResult !== null}
                     result={analysisResult}
                     error={analyseError}
                     onBenchmark={() => void handleBenchmark()}

--- a/Frontend/src/app/dashboard/schema-advisor/page.tsx
+++ b/Frontend/src/app/dashboard/schema-advisor/page.tsx
@@ -7,7 +7,6 @@ import { ScanOutlined, CopyOutlined, ThunderboltOutlined, ExperimentOutlined, Pl
 import RecommendationList from "./RecommendationList/RecommendationList";
 import RefactoringPanel from "./RefactoringPanel/RefactoringPanel";
 import { useStyles } from "./style/styles";
-import { getDatabaseConnections, IDatabaseConnectionDto } from "@/services/databaseConnectionService";
 import {
     scanSchema,
     generateMigration,
@@ -17,8 +16,10 @@ import {
     IQueryPairResult,
     IBenchmarkQueryPair,
 } from "@/services/schemaAdvisorService";
-import { getScansByConnection, addScan, deleteScan, ISchemaAdvisorScanDto } from "@/services/schemaAdvisorHistoryService";
+import { ISchemaAdvisorScanDto } from "@/services/schemaAdvisorHistoryService";
 import { executeQuery } from "@/services/queryService";
+import { useDatabaseConnectionState, useDatabaseConnectionActions } from "@/providers/databaseConnection";
+import { useSchemaAdvisorHistoryState, useSchemaAdvisorHistoryActions } from "@/providers/schemaAdvisorHistory";
 
 const { Text } = Typography;
 
@@ -26,17 +27,17 @@ const { Text } = Typography;
 export default function SchemaAdvisorPage(): React.JSX.Element {
     const { styles } = useStyles();
 
-    const [connections, setConnections] = useState<IDatabaseConnectionDto[]>([]);
-    const [selectedConnectionId, setSelectedConnectionId] = useState<string | null>(null);
+    const { connections, selectedConnectionId } = useDatabaseConnectionState();
+    const { getConnections, setSelectedConnectionId } = useDatabaseConnectionActions();
+    const { scans: scanHistory, activeScanId } = useSchemaAdvisorHistoryState();
+    const { getScansByConnection, addScan, deleteScan, setActiveScanId } = useSchemaAdvisorHistoryActions();
+
+    const restoredConnections = connections.filter((c) => c.restoreStatus === 3);
 
     const [recommendations, setRecommendations] = useState<IRecommendationDto[]>([]);
     const [selectedId, setSelectedId] = useState<string | null>(null);
     const [scanError, setScanError] = useState<string | null>(null);
     const [isScanning, setIsScanning] = useState(false);
-
-    // Scan history
-    const [scanHistory, setScanHistory] = useState<ISchemaAdvisorScanDto[]>([]);
-    const [activeScanId, setActiveScanId] = useState<string | null>(null);
 
     const [isMigrationModalOpen, setIsMigrationModalOpen] = useState(false);
     const [migrationSql, setMigrationSql] = useState<string | null>(null);
@@ -63,28 +64,22 @@ export default function SchemaAdvisorPage(): React.JSX.Element {
     const [weightedImprovement, setWeightedImprovement] = useState<number | null>(null);
     const [compareError, setCompareError] = useState<string | null>(null);
 
-    const loadHistory = useCallback(async (connectionId: string): Promise<void> => {
-        const history = await getScansByConnection(connectionId);
-        setScanHistory(history);
-    }, []);
+    useEffect(() => {
+        void getConnections();
+    }, [getConnections]);
 
     useEffect(() => {
-        void getDatabaseConnections().then((items) => {
-            const restored = items.filter((c) => c.restoreStatus === 3);
-            setConnections(restored);
-            if (restored.length === 1) {
-                setSelectedConnectionId(restored[0].id);
-            }
-        });
-    }, []);
+        if (restoredConnections.length === 1 && !selectedConnectionId) {
+            setSelectedConnectionId(restoredConnections[0].id);
+        }
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+    }, [connections]);
 
     useEffect(() => {
         if (selectedConnectionId) {
-            void loadHistory(selectedConnectionId);
-        } else {
-            setScanHistory([]);
+            void getScansByConnection(selectedConnectionId);
         }
-    }, [selectedConnectionId, loadHistory]);
+    }, [selectedConnectionId, getScansByConnection]);
 
     const handleScanSchema = async (): Promise<void> => {
         if (!selectedConnectionId) return;
@@ -100,10 +95,7 @@ export default function SchemaAdvisorPage(): React.JSX.Element {
 
             if (output.error) {
                 setScanError(output.error);
-                // Save failed scan to history so the error is recorded
-                const saved = await addScan(selectedConnectionId, 0, null, output.error);
-                setScanHistory((prev) => [saved, ...prev]);
-                setActiveScanId(saved.id);
+                void addScan(selectedConnectionId, 0, null, output.error);
                 return;
             }
 
@@ -112,18 +104,14 @@ export default function SchemaAdvisorPage(): React.JSX.Element {
                 setSelectedId(output.recommendations[0].id);
             }
 
-            // Persist scan to history
-            const saved = await addScan(
+            void addScan(
                 selectedConnectionId,
                 output.recommendations.length,
                 JSON.stringify(output.recommendations),
                 null,
             );
-            setScanHistory((prev) => [saved, ...prev]);
-            setActiveScanId(saved.id);
         } catch (err) {
-            const msg = err instanceof Error ? err.message : "An unexpected error occurred.";
-            setScanError(msg);
+            setScanError(err instanceof Error ? err.message : "An unexpected error occurred.");
         } finally {
             setIsScanning(false);
         }
@@ -142,11 +130,9 @@ export default function SchemaAdvisorPage(): React.JSX.Element {
         }
     };
 
-    const handleDeleteScan = async (scanId: string): Promise<void> => {
-        await deleteScan(scanId);
-        setScanHistory((prev) => prev.filter((s) => s.id !== scanId));
+    const handleDeleteScan = (scanId: string): void => {
+        void deleteScan(scanId);
         if (activeScanId === scanId) {
-            setActiveScanId(null);
             setRecommendations([]);
             setSelectedId(null);
         }
@@ -279,7 +265,7 @@ export default function SchemaAdvisorPage(): React.JSX.Element {
 
     const selectedRecommendation = recommendations.find((r) => r.id === selectedId) ?? null;
 
-    const connectionOptions = connections.map((c) => ({
+    const connectionOptions = restoredConnections.map((c) => ({
         value: c.id,
         label: c.name,
     }));

--- a/Frontend/src/constants/ApiConstants.ts
+++ b/Frontend/src/constants/ApiConstants.ts
@@ -24,6 +24,8 @@ export const API_CONSTANTS = {
     GET_QUERY_HISTORY: `${API_BASE_URL}/api/services/app/queryHistory/getQueryHistoryByConnectionId`,
     ADD_QUERY_HISTORY: `${API_BASE_URL}/api/services/app/queryHistory/addQueryHistoryEntry`,
     DELETE_QUERY_HISTORY: `${API_BASE_URL}/api/services/app/queryHistory/deleteQueryHistoryEntry`,
+    GET_SCHEMA_WITH_RELATIONSHIPS: `${API_BASE_URL}/api/services/app/queryExecution/getSchemaWithRelationships`,
+    GENERATE_TEST_DATA: `${API_BASE_URL}/api/services/app/queryExecution/generateTestData`,
     GET_ALL_SCHEMA_SCANS: `${API_BASE_URL}/api/services/app/schemaAdvisorHistory/getAllScans`,
     GET_SCHEMA_SCANS_BY_CONNECTION: `${API_BASE_URL}/api/services/app/schemaAdvisorHistory/getScansByConnection`,
     ADD_SCHEMA_SCAN: `${API_BASE_URL}/api/services/app/schemaAdvisorHistory/addScan`,

--- a/Frontend/src/providers/databaseConnection/actions.tsx
+++ b/Frontend/src/providers/databaseConnection/actions.tsx
@@ -1,0 +1,71 @@
+import { createAction } from "redux-actions";
+import { IDatabaseConnectionDto } from "@/services/databaseConnectionService";
+import { IDatabaseConnectionStateContext } from "./context";
+
+type P = Partial<IDatabaseConnectionStateContext>;
+
+export enum DatabaseConnectionActionEnums {
+    getConnectionsPending = "GET_CONNECTIONS_PENDING",
+    getConnectionsSuccess = "GET_CONNECTIONS_SUCCESS",
+    getConnectionsError = "GET_CONNECTIONS_ERROR",
+
+    setSelectedConnectionId = "SET_SELECTED_CONNECTION_ID",
+
+    triggerDumpPending = "TRIGGER_DUMP_PENDING",
+    triggerDumpSuccess = "TRIGGER_DUMP_SUCCESS",
+    triggerDumpError = "TRIGGER_DUMP_ERROR",
+
+    triggerRestorePending = "TRIGGER_RESTORE_PENDING",
+    triggerRestoreSuccess = "TRIGGER_RESTORE_SUCCESS",
+    triggerRestoreError = "TRIGGER_RESTORE_ERROR",
+}
+
+export const getConnectionsPending = createAction<P>(
+    DatabaseConnectionActionEnums.getConnectionsPending,
+    () => ({ isPending: true, isSuccess: false, isError: false }),
+);
+
+export const getConnectionsSuccess = createAction<P, IDatabaseConnectionDto[]>(
+    DatabaseConnectionActionEnums.getConnectionsSuccess,
+    (connections) => ({ isPending: false, isSuccess: true, isError: false, connections }),
+);
+
+export const getConnectionsError = createAction<P>(
+    DatabaseConnectionActionEnums.getConnectionsError,
+    () => ({ isPending: false, isSuccess: false, isError: true }),
+);
+
+export const setSelectedConnectionId = createAction<P, string | null>(
+    DatabaseConnectionActionEnums.setSelectedConnectionId,
+    (selectedConnectionId) => ({ selectedConnectionId }),
+);
+
+export const triggerDumpPending = createAction<P>(
+    DatabaseConnectionActionEnums.triggerDumpPending,
+    () => ({ isPending: true, isSuccess: false, isError: false }),
+);
+
+export const triggerDumpSuccess = createAction<P, IDatabaseConnectionDto[]>(
+    DatabaseConnectionActionEnums.triggerDumpSuccess,
+    (connections) => ({ isPending: false, isSuccess: true, isError: false, connections }),
+);
+
+export const triggerDumpError = createAction<P>(
+    DatabaseConnectionActionEnums.triggerDumpError,
+    () => ({ isPending: false, isSuccess: false, isError: true }),
+);
+
+export const triggerRestorePending = createAction<P>(
+    DatabaseConnectionActionEnums.triggerRestorePending,
+    () => ({ isPending: true, isSuccess: false, isError: false }),
+);
+
+export const triggerRestoreSuccess = createAction<P, IDatabaseConnectionDto[]>(
+    DatabaseConnectionActionEnums.triggerRestoreSuccess,
+    (connections) => ({ isPending: false, isSuccess: true, isError: false, connections }),
+);
+
+export const triggerRestoreError = createAction<P>(
+    DatabaseConnectionActionEnums.triggerRestoreError,
+    () => ({ isPending: false, isSuccess: false, isError: true }),
+);

--- a/Frontend/src/providers/databaseConnection/context.tsx
+++ b/Frontend/src/providers/databaseConnection/context.tsx
@@ -1,0 +1,38 @@
+import { createContext } from "react";
+import { IDatabaseConnectionDto } from "@/services/databaseConnectionService";
+
+export interface IDatabaseConnectionStateContext {
+    isPending: boolean;
+    isSuccess: boolean;
+    isError: boolean;
+    connections: IDatabaseConnectionDto[];
+    selectedConnectionId: string | null;
+}
+
+export interface IDatabaseConnectionActionContext {
+    getConnections: () => void;
+    setSelectedConnectionId: (id: string | null) => void;
+    triggerDump: (id: string) => void;
+    triggerRestore: (id: string) => void;
+}
+
+export const INITIAL_STATE: IDatabaseConnectionStateContext = {
+    isPending: false,
+    isSuccess: false,
+    isError: false,
+    connections: [],
+    selectedConnectionId: null,
+};
+
+export const INITIAL_ACTION_STATE: IDatabaseConnectionActionContext = {
+    getConnections: () => {},
+    setSelectedConnectionId: () => {},
+    triggerDump: () => {},
+    triggerRestore: () => {},
+};
+
+export const DatabaseConnectionStateContext =
+    createContext<IDatabaseConnectionStateContext>(INITIAL_STATE);
+
+export const DatabaseConnectionActionContext =
+    createContext<IDatabaseConnectionActionContext | undefined>(undefined);

--- a/Frontend/src/providers/databaseConnection/index.tsx
+++ b/Frontend/src/providers/databaseConnection/index.tsx
@@ -1,0 +1,95 @@
+"use client";
+
+import React, { useCallback, useContext, useReducer } from "react";
+import {
+    getDatabaseConnections,
+    triggerDump as apiTriggerDump,
+    triggerRestore as apiTriggerRestore,
+} from "@/services/databaseConnectionService";
+import {
+    getConnectionsPending,
+    getConnectionsSuccess,
+    getConnectionsError,
+    setSelectedConnectionId as setSelectedConnectionIdAction,
+    triggerDumpPending,
+    triggerDumpSuccess,
+    triggerDumpError,
+    triggerRestorePending,
+    triggerRestoreSuccess,
+    triggerRestoreError,
+} from "./actions";
+import {
+    INITIAL_STATE,
+    DatabaseConnectionStateContext,
+    DatabaseConnectionActionContext,
+} from "./context";
+import { DatabaseConnectionReducer } from "./reducer";
+
+export const DatabaseConnectionProvider = ({ children }: { children: React.ReactNode }) => {
+    const [state, dispatch] = useReducer(DatabaseConnectionReducer, INITIAL_STATE);
+
+    const getConnections = useCallback(async () => {
+        dispatch(getConnectionsPending());
+        try {
+            const connections = await getDatabaseConnections();
+            dispatch(getConnectionsSuccess(connections));
+        } catch (error) {
+            console.error(error);
+            dispatch(getConnectionsError());
+        }
+    }, []);
+
+    const setSelectedConnectionId = useCallback((id: string | null) => {
+        dispatch(setSelectedConnectionIdAction(id));
+    }, []);
+
+    const triggerDump = useCallback(async (id: string) => {
+        dispatch(triggerDumpPending());
+        try {
+            await apiTriggerDump(id);
+            const connections = await getDatabaseConnections();
+            dispatch(triggerDumpSuccess(connections));
+        } catch (error) {
+            console.error(error);
+            dispatch(triggerDumpError());
+        }
+    }, []);
+
+    const triggerRestore = useCallback(async (id: string) => {
+        dispatch(triggerRestorePending());
+        try {
+            await apiTriggerRestore(id);
+            const connections = await getDatabaseConnections();
+            dispatch(triggerRestoreSuccess(connections));
+        } catch (error) {
+            console.error(error);
+            dispatch(triggerRestoreError());
+        }
+    }, []);
+
+    return (
+        <DatabaseConnectionStateContext.Provider value={state}>
+            <DatabaseConnectionActionContext.Provider
+                value={{ getConnections, setSelectedConnectionId, triggerDump, triggerRestore }}
+            >
+                {children}
+            </DatabaseConnectionActionContext.Provider>
+        </DatabaseConnectionStateContext.Provider>
+    );
+};
+
+export const useDatabaseConnectionState = () => {
+    const context = useContext(DatabaseConnectionStateContext);
+    if (!context) {
+        throw new Error("useDatabaseConnectionState must be used within a DatabaseConnectionProvider");
+    }
+    return context;
+};
+
+export const useDatabaseConnectionActions = () => {
+    const context = useContext(DatabaseConnectionActionContext);
+    if (!context) {
+        throw new Error("useDatabaseConnectionActions must be used within a DatabaseConnectionProvider");
+    }
+    return context;
+};

--- a/Frontend/src/providers/databaseConnection/reducer.tsx
+++ b/Frontend/src/providers/databaseConnection/reducer.tsx
@@ -1,0 +1,24 @@
+import { handleActions } from "redux-actions";
+import { INITIAL_STATE, IDatabaseConnectionStateContext } from "./context";
+import { DatabaseConnectionActionEnums } from "./actions";
+
+type P = Partial<IDatabaseConnectionStateContext>;
+
+export const DatabaseConnectionReducer = handleActions<IDatabaseConnectionStateContext, P>(
+    {
+        [DatabaseConnectionActionEnums.getConnectionsPending]: (state, action) => ({ ...state, ...action.payload }),
+        [DatabaseConnectionActionEnums.getConnectionsSuccess]: (state, action) => ({ ...state, ...action.payload }),
+        [DatabaseConnectionActionEnums.getConnectionsError]: (state, action) => ({ ...state, ...action.payload }),
+
+        [DatabaseConnectionActionEnums.setSelectedConnectionId]: (state, action) => ({ ...state, ...action.payload }),
+
+        [DatabaseConnectionActionEnums.triggerDumpPending]: (state, action) => ({ ...state, ...action.payload }),
+        [DatabaseConnectionActionEnums.triggerDumpSuccess]: (state, action) => ({ ...state, ...action.payload }),
+        [DatabaseConnectionActionEnums.triggerDumpError]: (state, action) => ({ ...state, ...action.payload }),
+
+        [DatabaseConnectionActionEnums.triggerRestorePending]: (state, action) => ({ ...state, ...action.payload }),
+        [DatabaseConnectionActionEnums.triggerRestoreSuccess]: (state, action) => ({ ...state, ...action.payload }),
+        [DatabaseConnectionActionEnums.triggerRestoreError]: (state, action) => ({ ...state, ...action.payload }),
+    },
+    INITIAL_STATE,
+);

--- a/Frontend/src/providers/queryHistory/actions.tsx
+++ b/Frontend/src/providers/queryHistory/actions.tsx
@@ -1,0 +1,64 @@
+import { createAction } from "redux-actions";
+import { IQueryHistoryDto } from "@/services/queryHistoryService";
+import { IQueryHistoryStateContext } from "./context";
+
+type P = Partial<IQueryHistoryStateContext> & { entry?: IQueryHistoryDto; deletedId?: string };
+
+export enum QueryHistoryActionEnums {
+    getHistoryPending = "GET_QUERY_HISTORY_PENDING",
+    getHistorySuccess = "GET_QUERY_HISTORY_SUCCESS",
+    getHistoryError = "GET_QUERY_HISTORY_ERROR",
+
+    addEntryPending = "ADD_QUERY_HISTORY_PENDING",
+    addEntrySuccess = "ADD_QUERY_HISTORY_SUCCESS",
+    addEntryError = "ADD_QUERY_HISTORY_ERROR",
+
+    deleteEntryPending = "DELETE_QUERY_HISTORY_PENDING",
+    deleteEntrySuccess = "DELETE_QUERY_HISTORY_SUCCESS",
+    deleteEntryError = "DELETE_QUERY_HISTORY_ERROR",
+}
+
+export const getHistoryPending = createAction<P>(
+    QueryHistoryActionEnums.getHistoryPending,
+    () => ({ isPending: true, isSuccess: false, isError: false }),
+);
+
+export const getHistorySuccess = createAction<P, IQueryHistoryDto[]>(
+    QueryHistoryActionEnums.getHistorySuccess,
+    (entries) => ({ isPending: false, isSuccess: true, isError: false, entries }),
+);
+
+export const getHistoryError = createAction<P>(
+    QueryHistoryActionEnums.getHistoryError,
+    () => ({ isPending: false, isSuccess: false, isError: true }),
+);
+
+export const addEntryPending = createAction<P>(
+    QueryHistoryActionEnums.addEntryPending,
+    () => ({ isPending: true, isSuccess: false, isError: false }),
+);
+
+export const addEntrySuccess = createAction<P, IQueryHistoryDto>(
+    QueryHistoryActionEnums.addEntrySuccess,
+    (entry) => ({ isPending: false, isSuccess: true, isError: false, entry }),
+);
+
+export const addEntryError = createAction<P>(
+    QueryHistoryActionEnums.addEntryError,
+    () => ({ isPending: false, isSuccess: false, isError: true }),
+);
+
+export const deleteEntryPending = createAction<P>(
+    QueryHistoryActionEnums.deleteEntryPending,
+    () => ({ isPending: true, isSuccess: false, isError: false }),
+);
+
+export const deleteEntrySuccess = createAction<P, string>(
+    QueryHistoryActionEnums.deleteEntrySuccess,
+    (deletedId) => ({ isPending: false, isSuccess: true, isError: false, deletedId }),
+);
+
+export const deleteEntryError = createAction<P>(
+    QueryHistoryActionEnums.deleteEntryError,
+    () => ({ isPending: false, isSuccess: false, isError: true }),
+);

--- a/Frontend/src/providers/queryHistory/context.tsx
+++ b/Frontend/src/providers/queryHistory/context.tsx
@@ -1,0 +1,36 @@
+import { createContext } from "react";
+import { IQueryHistoryDto, IAddQueryHistoryRequest } from "@/services/queryHistoryService";
+
+export interface IQueryHistoryStateContext {
+    isPending: boolean;
+    isSuccess: boolean;
+    isError: boolean;
+    entries: IQueryHistoryDto[];
+}
+
+export interface IQueryHistoryActionContext {
+    getHistoryByConnection: (connectionId: string) => void;
+    getAllHistory: () => void;
+    addEntry: (request: IAddQueryHistoryRequest) => void;
+    deleteEntry: (entryId: string) => void;
+}
+
+export const INITIAL_STATE: IQueryHistoryStateContext = {
+    isPending: false,
+    isSuccess: false,
+    isError: false,
+    entries: [],
+};
+
+export const INITIAL_ACTION_STATE: IQueryHistoryActionContext = {
+    getHistoryByConnection: () => {},
+    getAllHistory: () => {},
+    addEntry: () => {},
+    deleteEntry: () => {},
+};
+
+export const QueryHistoryStateContext =
+    createContext<IQueryHistoryStateContext>(INITIAL_STATE);
+
+export const QueryHistoryActionContext =
+    createContext<IQueryHistoryActionContext | undefined>(undefined);

--- a/Frontend/src/providers/queryHistory/index.tsx
+++ b/Frontend/src/providers/queryHistory/index.tsx
@@ -1,0 +1,113 @@
+"use client";
+
+import React, { useCallback, useContext, useReducer } from "react";
+import {
+    getAllQueryHistory,
+    getQueryHistory,
+    addQueryHistory,
+    deleteQueryHistory,
+    IAddQueryHistoryRequest,
+    IQueryHistoryDto,
+} from "@/services/queryHistoryService";
+import {
+    getHistoryPending,
+    getHistorySuccess,
+    getHistoryError,
+    addEntryPending,
+    addEntrySuccess,
+    addEntryError,
+    deleteEntryPending,
+    deleteEntrySuccess,
+    deleteEntryError,
+} from "./actions";
+import {
+    INITIAL_STATE,
+    QueryHistoryStateContext,
+    QueryHistoryActionContext,
+} from "./context";
+import { QueryHistoryReducer } from "./reducer";
+
+export const QueryHistoryProvider = ({ children }: { children: React.ReactNode }) => {
+    const [state, dispatch] = useReducer(QueryHistoryReducer, INITIAL_STATE);
+
+    const getAllHistory = useCallback(async () => {
+        dispatch(getHistoryPending());
+        try {
+            const entries = await getAllQueryHistory();
+            dispatch(getHistorySuccess(entries));
+        } catch (error) {
+            console.error(error);
+            dispatch(getHistoryError());
+        }
+    }, []);
+
+    const getHistoryByConnection = useCallback(async (connectionId: string) => {
+        dispatch(getHistoryPending());
+        try {
+            const entries = await getQueryHistory(connectionId);
+            dispatch(getHistorySuccess(entries));
+        } catch (error) {
+            console.error(error);
+            dispatch(getHistoryError());
+        }
+    }, []);
+
+    const addEntry = useCallback(async (request: IAddQueryHistoryRequest) => {
+        dispatch(addEntryPending());
+        try {
+            await addQueryHistory(request);
+            // Optimistically add a placeholder; caller can refresh via getHistoryByConnection
+            const placeholder: IQueryHistoryDto = {
+                id: crypto.randomUUID(),
+                databaseConnectionId: request.databaseConnectionId,
+                queryText: request.queryText,
+                suggestedQuery: request.suggestedQuery ?? null,
+                resultSummary: request.resultSummary ?? null,
+                errorMessage: request.errorMessage ?? null,
+                executionTime: request.executionTime ?? "00:00:00",
+                creationTime: new Date().toISOString(),
+            };
+            dispatch(addEntrySuccess(placeholder));
+        } catch (error) {
+            console.error(error);
+            dispatch(addEntryError());
+        }
+    }, []);
+
+    const deleteEntry = useCallback(async (entryId: string) => {
+        dispatch(deleteEntryPending());
+        try {
+            await deleteQueryHistory(entryId);
+            dispatch(deleteEntrySuccess(entryId));
+        } catch (error) {
+            console.error(error);
+            dispatch(deleteEntryError());
+        }
+    }, []);
+
+    return (
+        <QueryHistoryStateContext.Provider value={state}>
+            <QueryHistoryActionContext.Provider
+                value={{ getAllHistory, getHistoryByConnection, addEntry, deleteEntry }}
+            >
+                {children}
+            </QueryHistoryActionContext.Provider>
+        </QueryHistoryStateContext.Provider>
+    );
+};
+
+export const useQueryHistoryState = () => {
+    const context = useContext(QueryHistoryStateContext);
+    if (!context) {
+        throw new Error("useQueryHistoryState must be used within a QueryHistoryProvider");
+    }
+    return context;
+};
+
+export const useQueryHistoryActions = () => {
+    const context = useContext(QueryHistoryActionContext);
+    if (!context) {
+        throw new Error("useQueryHistoryActions must be used within a QueryHistoryProvider");
+    }
+    return context;
+};

--- a/Frontend/src/providers/queryHistory/reducer.tsx
+++ b/Frontend/src/providers/queryHistory/reducer.tsx
@@ -1,0 +1,37 @@
+import { handleActions } from "redux-actions";
+import { INITIAL_STATE, IQueryHistoryStateContext } from "./context";
+import { QueryHistoryActionEnums } from "./actions";
+import { IQueryHistoryDto } from "@/services/queryHistoryService";
+
+type P = Partial<IQueryHistoryStateContext> & { entry?: IQueryHistoryDto; deletedId?: string };
+
+export const QueryHistoryReducer = handleActions<IQueryHistoryStateContext, P>(
+    {
+        [QueryHistoryActionEnums.getHistoryPending]: (state, action) => ({ ...state, ...action.payload }),
+        [QueryHistoryActionEnums.getHistorySuccess]: (state, action) => ({ ...state, ...action.payload }),
+        [QueryHistoryActionEnums.getHistoryError]: (state, action) => ({ ...state, ...action.payload }),
+
+        [QueryHistoryActionEnums.addEntryPending]: (state, action) => ({ ...state, ...action.payload }),
+        [QueryHistoryActionEnums.addEntrySuccess]: (state, action) => ({
+            ...state,
+            isPending: false,
+            isSuccess: true,
+            isError: false,
+            entries: action.payload.entry
+                ? [action.payload.entry, ...state.entries]
+                : state.entries,
+        }),
+        [QueryHistoryActionEnums.addEntryError]: (state, action) => ({ ...state, ...action.payload }),
+
+        [QueryHistoryActionEnums.deleteEntryPending]: (state, action) => ({ ...state, ...action.payload }),
+        [QueryHistoryActionEnums.deleteEntrySuccess]: (state, action) => ({
+            ...state,
+            isPending: false,
+            isSuccess: true,
+            isError: false,
+            entries: state.entries.filter((e) => e.id !== action.payload.deletedId),
+        }),
+        [QueryHistoryActionEnums.deleteEntryError]: (state, action) => ({ ...state, ...action.payload }),
+    },
+    INITIAL_STATE,
+);

--- a/Frontend/src/providers/schemaAdvisorHistory/actions.tsx
+++ b/Frontend/src/providers/schemaAdvisorHistory/actions.tsx
@@ -1,0 +1,71 @@
+import { createAction } from "redux-actions";
+import { ISchemaAdvisorScanDto } from "@/services/schemaAdvisorHistoryService";
+import { ISchemaAdvisorHistoryStateContext } from "./context";
+
+type P = Partial<ISchemaAdvisorHistoryStateContext> & { scan?: ISchemaAdvisorScanDto; deletedId?: string };
+
+export enum SchemaAdvisorHistoryActionEnums {
+    getScansPending = "GET_SCHEMA_SCANS_PENDING",
+    getScansSuccess = "GET_SCHEMA_SCANS_SUCCESS",
+    getScansError = "GET_SCHEMA_SCANS_ERROR",
+
+    addScanPending = "ADD_SCHEMA_SCAN_PENDING",
+    addScanSuccess = "ADD_SCHEMA_SCAN_SUCCESS",
+    addScanError = "ADD_SCHEMA_SCAN_ERROR",
+
+    deleteScanPending = "DELETE_SCHEMA_SCAN_PENDING",
+    deleteScanSuccess = "DELETE_SCHEMA_SCAN_SUCCESS",
+    deleteScanError = "DELETE_SCHEMA_SCAN_ERROR",
+
+    setActiveScanId = "SET_ACTIVE_SCAN_ID",
+}
+
+export const getScansPending = createAction<P>(
+    SchemaAdvisorHistoryActionEnums.getScansPending,
+    () => ({ isPending: true, isSuccess: false, isError: false }),
+);
+
+export const getScansSuccess = createAction<P, ISchemaAdvisorScanDto[]>(
+    SchemaAdvisorHistoryActionEnums.getScansSuccess,
+    (scans) => ({ isPending: false, isSuccess: true, isError: false, scans }),
+);
+
+export const getScansError = createAction<P>(
+    SchemaAdvisorHistoryActionEnums.getScansError,
+    () => ({ isPending: false, isSuccess: false, isError: true }),
+);
+
+export const addScanPending = createAction<P>(
+    SchemaAdvisorHistoryActionEnums.addScanPending,
+    () => ({ isPending: true, isSuccess: false, isError: false }),
+);
+
+export const addScanSuccess = createAction<P, ISchemaAdvisorScanDto>(
+    SchemaAdvisorHistoryActionEnums.addScanSuccess,
+    (scan) => ({ isPending: false, isSuccess: true, isError: false, scan }),
+);
+
+export const addScanError = createAction<P>(
+    SchemaAdvisorHistoryActionEnums.addScanError,
+    () => ({ isPending: false, isSuccess: false, isError: true }),
+);
+
+export const deleteScanPending = createAction<P>(
+    SchemaAdvisorHistoryActionEnums.deleteScanPending,
+    () => ({ isPending: true, isSuccess: false, isError: false }),
+);
+
+export const deleteScanSuccess = createAction<P, string>(
+    SchemaAdvisorHistoryActionEnums.deleteScanSuccess,
+    (deletedId) => ({ isPending: false, isSuccess: true, isError: false, deletedId }),
+);
+
+export const deleteScanError = createAction<P>(
+    SchemaAdvisorHistoryActionEnums.deleteScanError,
+    () => ({ isPending: false, isSuccess: false, isError: true }),
+);
+
+export const setActiveScanId = createAction<P, string | null>(
+    SchemaAdvisorHistoryActionEnums.setActiveScanId,
+    (activeScanId) => ({ activeScanId }),
+);

--- a/Frontend/src/providers/schemaAdvisorHistory/context.tsx
+++ b/Frontend/src/providers/schemaAdvisorHistory/context.tsx
@@ -1,0 +1,38 @@
+import { createContext } from "react";
+import { ISchemaAdvisorScanDto } from "@/services/schemaAdvisorHistoryService";
+
+export interface ISchemaAdvisorHistoryStateContext {
+    isPending: boolean;
+    isSuccess: boolean;
+    isError: boolean;
+    scans: ISchemaAdvisorScanDto[];
+    activeScanId: string | null;
+}
+
+export interface ISchemaAdvisorHistoryActionContext {
+    getScansByConnection: (connectionId: string) => void;
+    addScan: (connectionId: string, recommendationCount: number, recommendationsJson: string | null, errorMessage: string | null) => void;
+    deleteScan: (scanId: string) => void;
+    setActiveScanId: (scanId: string | null) => void;
+}
+
+export const INITIAL_STATE: ISchemaAdvisorHistoryStateContext = {
+    isPending: false,
+    isSuccess: false,
+    isError: false,
+    scans: [],
+    activeScanId: null,
+};
+
+export const INITIAL_ACTION_STATE: ISchemaAdvisorHistoryActionContext = {
+    getScansByConnection: () => {},
+    addScan: () => {},
+    deleteScan: () => {},
+    setActiveScanId: () => {},
+};
+
+export const SchemaAdvisorHistoryStateContext =
+    createContext<ISchemaAdvisorHistoryStateContext>(INITIAL_STATE);
+
+export const SchemaAdvisorHistoryActionContext =
+    createContext<ISchemaAdvisorHistoryActionContext | undefined>(undefined);

--- a/Frontend/src/providers/schemaAdvisorHistory/index.tsx
+++ b/Frontend/src/providers/schemaAdvisorHistory/index.tsx
@@ -1,0 +1,98 @@
+"use client";
+
+import React, { useCallback, useContext, useReducer } from "react";
+import {
+    getScansByConnection as apiGetScansByConnection,
+    addScan as apiAddScan,
+    deleteScan as apiDeleteScan,
+} from "@/services/schemaAdvisorHistoryService";
+import {
+    getScansPending,
+    getScansSuccess,
+    getScansError,
+    addScanPending,
+    addScanSuccess,
+    addScanError,
+    deleteScanPending,
+    deleteScanSuccess,
+    deleteScanError,
+    setActiveScanId as setActiveScanIdAction,
+} from "./actions";
+import {
+    INITIAL_STATE,
+    SchemaAdvisorHistoryStateContext,
+    SchemaAdvisorHistoryActionContext,
+} from "./context";
+import { SchemaAdvisorHistoryReducer } from "./reducer";
+
+export const SchemaAdvisorHistoryProvider = ({ children }: { children: React.ReactNode }) => {
+    const [state, dispatch] = useReducer(SchemaAdvisorHistoryReducer, INITIAL_STATE);
+
+    const getScansByConnection = useCallback(async (connectionId: string) => {
+        dispatch(getScansPending());
+        try {
+            const scans = await apiGetScansByConnection(connectionId);
+            dispatch(getScansSuccess(scans));
+        } catch (error) {
+            console.error(error);
+            dispatch(getScansError());
+        }
+    }, []);
+
+    const addScan = useCallback(async (
+        connectionId: string,
+        recommendationCount: number,
+        recommendationsJson: string | null,
+        errorMessage: string | null,
+    ) => {
+        dispatch(addScanPending());
+        try {
+            const scan = await apiAddScan(connectionId, recommendationCount, recommendationsJson, errorMessage);
+            dispatch(addScanSuccess(scan));
+        } catch (error) {
+            console.error(error);
+            dispatch(addScanError());
+        }
+    }, []);
+
+    const deleteScan = useCallback(async (scanId: string) => {
+        dispatch(deleteScanPending());
+        try {
+            await apiDeleteScan(scanId);
+            dispatch(deleteScanSuccess(scanId));
+        } catch (error) {
+            console.error(error);
+            dispatch(deleteScanError());
+        }
+    }, []);
+
+    const setActiveScanId = useCallback((scanId: string | null) => {
+        dispatch(setActiveScanIdAction(scanId));
+    }, []);
+
+    return (
+        <SchemaAdvisorHistoryStateContext.Provider value={state}>
+            <SchemaAdvisorHistoryActionContext.Provider
+                value={{ getScansByConnection, addScan, deleteScan, setActiveScanId }}
+            >
+                {children}
+            </SchemaAdvisorHistoryActionContext.Provider>
+        </SchemaAdvisorHistoryStateContext.Provider>
+    );
+};
+
+export const useSchemaAdvisorHistoryState = () => {
+    const context = useContext(SchemaAdvisorHistoryStateContext);
+    if (!context) {
+        throw new Error("useSchemaAdvisorHistoryState must be used within a SchemaAdvisorHistoryProvider");
+    }
+    return context;
+};
+
+export const useSchemaAdvisorHistoryActions = () => {
+    const context = useContext(SchemaAdvisorHistoryActionContext);
+    if (!context) {
+        throw new Error("useSchemaAdvisorHistoryActions must be used within a SchemaAdvisorHistoryProvider");
+    }
+    return context;
+};

--- a/Frontend/src/providers/schemaAdvisorHistory/reducer.tsx
+++ b/Frontend/src/providers/schemaAdvisorHistory/reducer.tsx
@@ -1,0 +1,39 @@
+import { handleActions } from "redux-actions";
+import { INITIAL_STATE, ISchemaAdvisorHistoryStateContext } from "./context";
+import { SchemaAdvisorHistoryActionEnums } from "./actions";
+import { ISchemaAdvisorScanDto } from "@/services/schemaAdvisorHistoryService";
+
+type P = Partial<ISchemaAdvisorHistoryStateContext> & { scan?: ISchemaAdvisorScanDto; deletedId?: string };
+
+export const SchemaAdvisorHistoryReducer = handleActions<ISchemaAdvisorHistoryStateContext, P>(
+    {
+        [SchemaAdvisorHistoryActionEnums.getScansPending]: (state, action) => ({ ...state, ...action.payload }),
+        [SchemaAdvisorHistoryActionEnums.getScansSuccess]: (state, action) => ({ ...state, ...action.payload }),
+        [SchemaAdvisorHistoryActionEnums.getScansError]: (state, action) => ({ ...state, ...action.payload }),
+
+        [SchemaAdvisorHistoryActionEnums.addScanPending]: (state, action) => ({ ...state, ...action.payload }),
+        [SchemaAdvisorHistoryActionEnums.addScanSuccess]: (state, action) => ({
+            ...state,
+            isPending: false,
+            isSuccess: true,
+            isError: false,
+            scans: action.payload.scan ? [action.payload.scan, ...state.scans] : state.scans,
+            activeScanId: action.payload.scan?.id ?? state.activeScanId,
+        }),
+        [SchemaAdvisorHistoryActionEnums.addScanError]: (state, action) => ({ ...state, ...action.payload }),
+
+        [SchemaAdvisorHistoryActionEnums.deleteScanPending]: (state, action) => ({ ...state, ...action.payload }),
+        [SchemaAdvisorHistoryActionEnums.deleteScanSuccess]: (state, action) => ({
+            ...state,
+            isPending: false,
+            isSuccess: true,
+            isError: false,
+            scans: state.scans.filter((s) => s.id !== action.payload.deletedId),
+            activeScanId: state.activeScanId === action.payload.deletedId ? null : state.activeScanId,
+        }),
+        [SchemaAdvisorHistoryActionEnums.deleteScanError]: (state, action) => ({ ...state, ...action.payload }),
+
+        [SchemaAdvisorHistoryActionEnums.setActiveScanId]: (state, action) => ({ ...state, ...action.payload }),
+    },
+    INITIAL_STATE,
+);

--- a/Frontend/src/services/queryService.ts
+++ b/Frontend/src/services/queryService.ts
@@ -84,6 +84,74 @@ export async function benchmarkQuery(request: IBenchmarkRequest): Promise<IBench
     return json.result as IBenchmarkResponse;
 }
 
+export interface ISchemaColumn {
+    name: string;
+    dataType: string;
+    isNullable: boolean;
+    isPrimaryKey: boolean;
+    maxLength: number | null;
+    referencesTable: string | null;
+    referencesColumn: string | null;
+}
+
+export interface ISchemaTableDetail {
+    name: string;
+    columns: ISchemaColumn[];
+}
+
+export interface ISchemaRelationship {
+    fromTable: string;
+    fromColumn: string;
+    toTable: string;
+    toColumn: string;
+}
+
+export interface ISchemaWithRelationships {
+    tables: ISchemaTableDetail[];
+    relationships: ISchemaRelationship[];
+}
+
+export interface ITableRowCount {
+    tableName: string;
+    rowCount: number;
+}
+
+export interface IGenerateTestDataRequest {
+    connectionId: string;
+    tables: ITableRowCount[];
+}
+
+export interface IGenerateTestDataResponse {
+    success: boolean;
+    insertedCounts: Record<string, number>;
+    error: string | null;
+}
+
+/** Fetches detailed schema (column types, PK/FK info) and FK relationships for a connection. */
+export async function getSchemaWithRelationships(connectionId: string): Promise<ISchemaWithRelationships> {
+    const url = `${API_CONSTANTS.GET_SCHEMA_WITH_RELATIONSHIPS}?connectionId=${encodeURIComponent(connectionId)}`;
+    const response = await fetch(url, { headers: authHeaders() });
+
+    if (!response.ok) {
+        throw new Error(`Schema fetch failed: ${response.status}`);
+    }
+
+    const json = await response.json();
+    return json.result as ISchemaWithRelationships;
+}
+
+/** Generates and inserts AI-produced test data into the local schema-only database. */
+export async function generateTestData(request: IGenerateTestDataRequest): Promise<IGenerateTestDataResponse> {
+    const response = await fetch(API_CONSTANTS.GENERATE_TEST_DATA, {
+        method: "POST",
+        headers: authHeaders(),
+        body: JSON.stringify(request),
+    });
+
+    const json = await response.json();
+    return json.result as IGenerateTestDataResponse;
+}
+
 /** Fetches the schema (tables + columns) for the local copy of the given connection's database. */
 export async function getSchema(connectionId: string): Promise<ISchemaTable[]> {
     const url = `${API_CONSTANTS.GET_SCHEMA}?connectionId=${encodeURIComponent(connectionId)}`;


### PR DESCRIPTION
## Summary

- **React Context providers** for shared state management across all dashboard pages (`DatabaseConnection`, `QueryHistory`, `SchemaAdvisorHistory`), replacing direct service calls in every page component
- **Schema Advisor scan history** — saves every scan to the backend and displays a history panel in the Schema Advisor page with one-click restore
- **Schema-only data generator** — connection cards with Schema Only enabled now show a Generate Data button that opens a drawer to browse all tables/relationships and generate AI-powered test data respecting FK constraints
- **Bug fixes** — provider action functions wrapped in `useCallback` to prevent infinite re-render loops; `try/catch/finally` added to all async handlers so loading spinners always clear on error

## Closes

- Closes #86 — Save and display Schema Advisor scan history
- Closes #88 — Schema-only data generator — browse tables, relationships, and generate AI test data

