### PR TITLE
fix: add missing System using in DbContextConfigurer

### DIFF
--- a/Backend/aspnet-core/src/sql_optimizer.EntityFrameworkCore/EntityFrameworkCore/sql_optimizerDbContextConfigurer.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.EntityFrameworkCore/EntityFrameworkCore/sql_optimizerDbContextConfigurer.cs
@@ -1,6 +1,7 @@
+using System;
+using System.Data.Common;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
-using System.Data.Common;
 
 namespace sql_optimizer.EntityFrameworkCore;
 


### PR DESCRIPTION
## Summary
- Adds `using System;` to `sql_optimizerDbContextConfigurer.cs` — fixes build error `CS0103: The name 'TimeSpan' does not exist in the current context`

