### PR TITLE
fix: run EF migrations outside ABP unit of work

### DIFF
--- a/Backend/aspnet-core/src/sql_optimizer.EntityFrameworkCore/EntityFrameworkCore/Seed/SeedHelper.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.EntityFrameworkCore/EntityFrameworkCore/Seed/SeedHelper.cs
@@ -21,9 +21,6 @@ public static class SeedHelper
     {
         context.SuppressAutoSetTenantId = true;
 
-        // Apply any pending EF Core migrations before seeding
-        context.Database.Migrate();
-
         // Host seed
         new InitialHostDbBuilder(context).Create();
 

--- a/Backend/aspnet-core/src/sql_optimizer.EntityFrameworkCore/EntityFrameworkCore/sql_optimizerEntityFrameworkModule.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.EntityFrameworkCore/EntityFrameworkCore/sql_optimizerEntityFrameworkModule.cs
@@ -2,6 +2,7 @@
 using Abp.Modules;
 using Abp.Reflection.Extensions;
 using Abp.Zero.EntityFrameworkCore;
+using Microsoft.EntityFrameworkCore;
 using sql_optimizer.EntityFrameworkCore.Seed;
 
 namespace sql_optimizer.EntityFrameworkCore;
@@ -41,8 +42,15 @@ public class sql_optimizerEntityFrameworkModule : AbpModule
 
     public override void PostInitialize()
     {
+        // Run EF Core migrations on a fresh, standalone context — before ABP's
+        // seeding UoW begins, so there is no transaction scope conflict.
         if (!SkipDbSeed)
         {
+            using (var context = IocManager.Resolve<sql_optimizerDbContext>())
+            {
+                context.Database.Migrate();
+            }
+
             SeedHelper.SeedHostDb(IocManager);
         }
     }


### PR DESCRIPTION
## Summary
- `Database.Migrate()` was being called inside ABP's `WithDbContext` UoW helper, causing a crash on startup due to transaction scope conflict.
- Fix: move `Migrate()` to `PostInitialize()` in `sql_optimizerEntityFrameworkModule` using a fresh standalone `DbContext` resolved via `IocManager`, before seeding begins.

