### PR TITLE
fix: remove EnableRetryOnFailure — incompatible with ABP UoW transactions

### DIFF
--- a/Backend/aspnet-core/src/sql_optimizer.EntityFrameworkCore/EntityFrameworkCore/sql_optimizerDbContextConfigurer.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.EntityFrameworkCore/EntityFrameworkCore/sql_optimizerDbContextConfigurer.cs
@@ -1,4 +1,3 @@
-using System;
 using System.Data.Common;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Diagnostics;
@@ -9,11 +8,7 @@ public static class sql_optimizerDbContextConfigurer
 {
     public static void Configure(DbContextOptionsBuilder<sql_optimizerDbContext> builder, string connectionString)
     {
-        builder.UseNpgsql(connectionString, npgsqlOptions =>
-        {
-            // Retry up to 3 times on transient failures (e.g. stale pooled connections timing out)
-            npgsqlOptions.EnableRetryOnFailure(3, TimeSpan.FromSeconds(5), null);
-        });
+        builder.UseNpgsql(connectionString);
         builder.ConfigureWarnings(w => w.Ignore(RelationalEventId.PendingModelChangesWarning));
     }
 

--- a/Backend/aspnet-core/src/sql_optimizer.EntityFrameworkCore/EntityFrameworkCore/sql_optimizerEntityFrameworkModule.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.EntityFrameworkCore/EntityFrameworkCore/sql_optimizerEntityFrameworkModule.cs
@@ -2,7 +2,6 @@
 using Abp.Modules;
 using Abp.Reflection.Extensions;
 using Abp.Zero.EntityFrameworkCore;
-using Microsoft.EntityFrameworkCore;
 using sql_optimizer.EntityFrameworkCore.Seed;
 
 namespace sql_optimizer.EntityFrameworkCore;
@@ -42,15 +41,8 @@ public class sql_optimizerEntityFrameworkModule : AbpModule
 
     public override void PostInitialize()
     {
-        // Run EF Core migrations on a fresh, standalone context — before ABP's
-        // seeding UoW begins, so there is no transaction scope conflict.
         if (!SkipDbSeed)
         {
-            using (var context = IocManager.Resolve<sql_optimizerDbContext>())
-            {
-                context.Database.Migrate();
-            }
-
             SeedHelper.SeedHostDb(IocManager);
         }
     }


### PR DESCRIPTION
## Summary
- Removes `EnableRetryOnFailure` from `UseNpgsql` config — `NpgsqlRetryingExecutionStrategy` does not support user-initiated transactions, causing a crash during ABP seeding on startup.
- The `Keepalive=30;Connection Idle Lifetime=300` settings in the connection string still handle stale pooled connections.
- Also includes the revert of auto-migration from startup (migrations will be run manually).

