### PR TITLE
feat: UI fixes, signup page, and expanded schema advisor prompt

### DIFF
--- a/Backend/aspnet-core/src/sql_optimizer.Application/Services/SchemaAdvisorService/SchemaAdvisorAppService.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Application/Services/SchemaAdvisorService/SchemaAdvisorAppService.cs
@@ -57,7 +57,7 @@ public class SchemaAdvisorAppService : ApplicationService, ISchemaAdvisorAppServ
         }
 
         var systemPrompt = """
-            You are an expert PostgreSQL database architect specialising in normalisation and performance.
+            You are an expert PostgreSQL database architect specialising in performance tuning and schema design.
             Analyse the schema provided and return a JSON object with improvement recommendations.
             Respond with ONLY valid JSON — no markdown, no code fences, no extra text.
 
@@ -94,12 +94,49 @@ public class SchemaAdvisorAppService : ApplicationService, ISchemaAdvisorAppServ
             }
 
             Rules:
-            - "highlight": "warning" for problematic columns (large types, no index on FK, redundant data).
-            - "highlight": "new" for newly introduced columns in the proposed schema.
+            - "highlight": "warning" for problematic columns (oversized types, missing FK index, redundant data, functions on indexed columns).
+            - "highlight": "new" for newly introduced columns or tables in the proposed schema.
             - "highlight": null for ordinary columns with no change.
-            - Return 2–4 recommendations maximum, ordered by impact descending.
-            - Focus on: missing indexes on foreign keys or high-cardinality columns, wide tables with large column types, tables that would benefit from normalisation or a materialised view, columns storing multiple values in a single field.
+            - Return 3–6 recommendations maximum, ordered by impact descending.
             - Provide realistic before/after metric estimates based on the row counts and column types visible in the schema.
+
+            Consider ALL of the following optimisation categories — do not focus only on indexes:
+
+            1. NORMALISATION / DENORMALISATION
+               - Tables that violate 2NF/3NF (repeated groups, transitive dependencies).
+               - Wide tables that should be split, or over-normalised tables that should be merged for read performance.
+
+            2. DATA TYPE OPTIMISATION
+               - Columns using TEXT where VARCHAR(n) would enforce a known max length and reduce storage.
+               - Columns using VARCHAR where a fixed-length CHAR, integer enum, or smaller numeric type is more appropriate.
+               - Oversized numeric types (e.g. BIGINT where INTEGER suffices).
+
+            3. INDEX STRATEGY
+               - Missing indexes on foreign keys or high-cardinality filter/join columns.
+               - Redundant or duplicate indexes that increase write overhead without read benefit.
+               - Indexes that should be DROPPED on write-heavy tables where writes significantly outnumber reads.
+               - Composite indexes that could replace multiple single-column indexes.
+               - Partial indexes for tables with common WHERE predicates.
+
+            4. QUERY RESULT OPTIMISATION
+               - Tables or views where SELECT * is typical but only a subset of columns is actually needed — suggest explicit column lists or covering indexes.
+               - Opportunities to return only required columns to reduce network and memory overhead.
+
+            5. FUNCTION ON INDEXED COLUMNS
+               - Columns where queries likely apply functions (e.g. LOWER(email), DATE(created_at)) defeating index usage — suggest functional/expression indexes or schema changes to avoid the function.
+
+            6. JOIN OPTIMISATION
+               - Missing indexes on join keys.
+               - Opportunities to pre-compute or materialise frequent joins using materialised views.
+               - Denormalisation candidates where a join can be eliminated by storing a derived value.
+
+            7. STORED PROCEDURES / FUNCTIONS
+               - Patterns of repeated logic that would benefit from a PostgreSQL function or stored procedure to reduce round-trips and parsing overhead.
+
+            8. OTHER
+               - Columns storing multiple values in a single field (should be normalised to a child table).
+               - NULL-heavy optional columns that could be extracted to a separate table.
+               - Missing NOT NULL constraints on logically required columns.
             """;
 
         var userMessage = $"Database schema:\n\n{schemaContext}";

--- a/Frontend/src/app/dashboard/DashboardHeader/DashboardHeader.tsx
+++ b/Frontend/src/app/dashboard/DashboardHeader/DashboardHeader.tsx
@@ -1,22 +1,15 @@
 "use client";
 
-import { Input, Select } from "antd";
-import { DatabaseOutlined, SearchOutlined, BellOutlined, MenuOutlined } from "@ant-design/icons";
+import { BellOutlined, MenuOutlined } from "@ant-design/icons";
 import React from "react";
 import { useStyles } from "./style/styles";
-
-const CLUSTER_OPTIONS = [
-    { value: "staging-cluster-1", label: "staging-cluster-1" },
-    { value: "prod-main", label: "prod-main" },
-    { value: "prod-analytics", label: "prod-analytics" },
-];
 
 interface IDashboardHeaderProps {
     /** Opens the mobile sidebar drawer. */
     onMenuClick: () => void;
 }
 
-/** Top header bar with hamburger (mobile), cluster selector, search, notifications, and avatar. */
+/** Top header bar with hamburger (mobile), notifications, and avatar. */
 const DashboardHeader: React.FC<IDashboardHeaderProps> = ({ onMenuClick }) => {
     const { styles } = useStyles();
 
@@ -24,23 +17,8 @@ const DashboardHeader: React.FC<IDashboardHeaderProps> = ({ onMenuClick }) => {
         <header className={styles.header}>
             <div className={styles.leftGroup}>
                 <MenuOutlined className={styles.menuButton} onClick={onMenuClick} />
-                <div className={styles.clusterSelector}>
-                    <DatabaseOutlined className={styles.clusterIcon} />
-                    <Select
-                        defaultValue="staging-cluster-1"
-                        options={CLUSTER_OPTIONS}
-                        className={styles.clusterSelect}
-                    />
-                </div>
             </div>
             <div className={styles.rightActions}>
-                <Input
-                    prefix={<SearchOutlined />}
-                    placeholder="Search queries, tables..."
-                    suffix={<span className={styles.searchHint}>⌘ K</span>}
-                    className={styles.searchBar}
-                />
-                <SearchOutlined className={styles.searchIconButton} />
                 <BellOutlined className={styles.bellButton} />
                 <div className={styles.avatar} />
             </div>

--- a/Frontend/src/app/dashboard/DashboardSidebar/DashboardSidebar.tsx
+++ b/Frontend/src/app/dashboard/DashboardSidebar/DashboardSidebar.tsx
@@ -9,12 +9,13 @@ import {
     DatabaseOutlined,
     ApartmentOutlined,
     HistoryOutlined,
-    SettingOutlined,
+    LogoutOutlined,
 } from "@ant-design/icons";
-import { usePathname } from "next/navigation";
+import { usePathname, useRouter } from "next/navigation";
 import Link from "next/link";
 import React from "react";
 import { useStyles } from "./style/styles";
+import { tokenService } from "@/services/tokenService";
 
 const NAV_ITEMS = [
     { key: "/dashboard", icon: <AppstoreOutlined />, label: <Link href="/dashboard">Dashboard</Link> },
@@ -25,19 +26,25 @@ const NAV_ITEMS = [
     { key: "/dashboard/history", icon: <HistoryOutlined />, label: <Link href="/dashboard/history">History</Link> },
 ];
 
-const SETTINGS_ITEMS = [
-    { key: "/dashboard/settings", icon: <SettingOutlined />, label: <Link href="/dashboard/settings">Settings</Link> },
-];
-
 interface IDashboardSidebarProps {
     /** Called after a nav item is clicked — used to close the mobile drawer. */
     onNavClick?: () => void;
 }
 
-/** Left sidebar with branding, primary navigation, and settings link. */
+/** Left sidebar with branding, primary navigation, and sign-out button. */
 const DashboardSidebar: React.FC<IDashboardSidebarProps> = ({ onNavClick }) => {
     const { styles } = useStyles();
     const pathname = usePathname();
+    const router = useRouter();
+
+    const handleSignOut = (): void => {
+        tokenService.clear();
+        router.push("/login");
+    };
+
+    const SIGN_OUT_ITEMS = [
+        { key: "signout", icon: <LogoutOutlined />, label: "Sign Out", danger: true },
+    ];
 
     return (
         <div className={styles.sidebar}>
@@ -56,9 +63,9 @@ const DashboardSidebar: React.FC<IDashboardSidebarProps> = ({ onNavClick }) => {
             <div className={styles.settingsArea}>
                 <Menu
                     mode="inline"
-                    selectedKeys={[pathname]}
-                    items={SETTINGS_ITEMS}
-                    onClick={onNavClick}
+                    selectedKeys={[]}
+                    items={SIGN_OUT_ITEMS}
+                    onClick={handleSignOut}
                 />
             </div>
         </div>

--- a/Frontend/src/app/dashboard/SystemOverview/DatabaseCards/DatabaseCards.tsx
+++ b/Frontend/src/app/dashboard/SystemOverview/DatabaseCards/DatabaseCards.tsx
@@ -28,6 +28,8 @@ const DatabaseCards: React.FC<IDatabaseCardsProps> = ({
 }) => {
     const { styles } = useStyles();
 
+    const showImprovement = averageImprovementPercent !== null;
+
     if (loading) {
         return (
             <div className={styles.cardsRow}>
@@ -39,10 +41,6 @@ const DatabaseCards: React.FC<IDatabaseCardsProps> = ({
             </div>
         );
     }
-
-    const improvementDisplay = averageImprovementPercent !== null
-        ? `${averageImprovementPercent}%`
-        : "N/A";
 
     return (
         <div className={styles.cardsRow}>
@@ -82,17 +80,19 @@ const DatabaseCards: React.FC<IDatabaseCardsProps> = ({
                 </div>
             </div>
 
-            <div className={styles.statCard}>
-                <div className={styles.statCardHeader}>
-                    <span className={styles.statCardName}>
-                        <RiseOutlined className={styles.statCardIcon} />
-                        Avg Improvement
-                    </span>
+            {showImprovement && (
+                <div className={styles.statCard}>
+                    <div className={styles.statCardHeader}>
+                        <span className={styles.statCardName}>
+                            <RiseOutlined className={styles.statCardIcon} />
+                            Avg Improvement
+                        </span>
+                    </div>
+                    <div className={styles.statValueFormatted}>
+                        {averageImprovementPercent}%
+                    </div>
                 </div>
-                <div className={styles.statValueFormatted}>
-                    {improvementDisplay}
-                </div>
-            </div>
+            )}
         </div>
     );
 };

--- a/Frontend/src/app/dashboard/databases/AddConnectionForm/AddConnectionForm.tsx
+++ b/Frontend/src/app/dashboard/databases/AddConnectionForm/AddConnectionForm.tsx
@@ -212,7 +212,7 @@ const AddConnectionForm: React.FC<IAddConnectionFormProps> = ({ onSaved }) => {
                     />
                 </div>
             </div>
-            <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12 }}>
+            <div style={{ display: "flex", alignItems: "center", gap: 8, marginBottom: 12, marginTop: 16 }}>
                 <Switch
                     id="conn-schema-only"
                     checked={schemaOnly}

--- a/Frontend/src/app/dashboard/databases/ConnectionCard/ConnectionCard.tsx
+++ b/Frontend/src/app/dashboard/databases/ConnectionCard/ConnectionCard.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { Button, Tag, Tooltip } from "antd";
-import { DatabaseOutlined, EditOutlined, CloudDownloadOutlined, ReloadOutlined, ThunderboltOutlined } from "@ant-design/icons";
+import { DatabaseOutlined, CloudDownloadOutlined, ReloadOutlined, ThunderboltOutlined } from "@ant-design/icons";
 import { useStyles } from "../style/styles";
 
 /** Connection status values for a database card. */
@@ -38,7 +38,6 @@ export interface IDatabase {
 
 interface IConnectionCardProps {
     database: IDatabase;
-    onEdit: () => void;
     onDump: () => void;
     onRebuild: () => void;
     onGenerateData: () => void;
@@ -47,7 +46,7 @@ interface IConnectionCardProps {
 }
 
 /** Card displaying a single database connection's metadata and status. */
-const ConnectionCard: React.FC<IConnectionCardProps> = ({ database, onEdit, onDump, onRebuild, onGenerateData, isDumping, isRebuilding }) => {
+const ConnectionCard: React.FC<IConnectionCardProps> = ({ database, onDump, onRebuild, onGenerateData, isDumping, isRebuilding }) => {
     const { styles } = useStyles();
 
     const dumpBusy = isDumping || database.dumpStatus === 1 || database.dumpStatus === 2;
@@ -118,7 +117,6 @@ const ConnectionCard: React.FC<IConnectionCardProps> = ({ database, onEdit, onDu
                         </Button>
                     </Tooltip>
                 )}
-                <Button type="text" size="small" icon={<EditOutlined />} onClick={onEdit}>Edit</Button>
             </div>
         </div>
     );

--- a/Frontend/src/app/dashboard/databases/ConnectionCardList/ConnectionCardList.tsx
+++ b/Frontend/src/app/dashboard/databases/ConnectionCardList/ConnectionCardList.tsx
@@ -8,7 +8,6 @@ import { useStyles } from "../style/styles";
 interface IConnectionCardListProps {
     databases: IDatabase[];
     isLoading: boolean;
-    onEdit: (id: string) => void;
     onDump: (id: string) => void;
     onRebuild: (id: string) => void;
     onGenerateData: (id: string) => void;
@@ -17,7 +16,7 @@ interface IConnectionCardListProps {
 }
 
 /** Grid of all registered database connection cards. */
-const ConnectionCardList: React.FC<IConnectionCardListProps> = ({ databases, isLoading, onEdit, onDump, onRebuild, onGenerateData, dumpingIds, rebuildingIds }) => {
+const ConnectionCardList: React.FC<IConnectionCardListProps> = ({ databases, isLoading, onDump, onRebuild, onGenerateData, dumpingIds, rebuildingIds }) => {
     const { styles } = useStyles();
 
     if (isLoading) {
@@ -40,7 +39,6 @@ const ConnectionCardList: React.FC<IConnectionCardListProps> = ({ databases, isL
                 <ConnectionCard
                     key={database.id}
                     database={database}
-                    onEdit={() => onEdit(database.id)}
                     onDump={() => onDump(database.id)}
                     onRebuild={() => onRebuild(database.id)}
                     onGenerateData={() => onGenerateData(database.id)}

--- a/Frontend/src/app/dashboard/databases/page.tsx
+++ b/Frontend/src/app/dashboard/databases/page.tsx
@@ -5,7 +5,6 @@ import { message } from "antd";
 import DatabasesHeader from "./DatabasesHeader/DatabasesHeader";
 import ConnectionCardList from "./ConnectionCardList/ConnectionCardList";
 import AddConnectionForm from "./AddConnectionForm/AddConnectionForm";
-import EditConnectionModal from "./EditConnectionModal/EditConnectionModal";
 import DataGeneratorDrawer from "./DataGeneratorDrawer/DataGeneratorDrawer";
 import { IDatabaseConnectionDto, DATABASE_ENGINE_NAMES, RESTORE_STATUS_LABELS } from "@/services/databaseConnectionService";
 import { useDatabaseConnectionState, useDatabaseConnectionActions } from "@/providers/databaseConnection";
@@ -39,7 +38,6 @@ export default function DatabasesPage(): React.JSX.Element {
     const { connections, isPending } = useDatabaseConnectionState();
     const { getConnections, triggerDump, triggerRestore } = useDatabaseConnectionActions();
 
-    const [editingConnection, setEditingConnection] = useState<IDatabaseConnectionDto | null>(null);
     const [dataGenConnectionId, setDataGenConnectionId] = useState<string | null>(null);
     const [dumpingIds, setDumpingIds] = useState<Set<string>>(new Set());
     const [rebuildingIds, setRebuildingIds] = useState<Set<string>>(new Set());
@@ -68,15 +66,6 @@ export default function DatabasesPage(): React.JSX.Element {
             startPolling();
         }
     }, [connections, startPolling]);
-
-    const handleEdit = (id: string): void => {
-        setEditingConnection(connections.find((c) => c.id === id) ?? null);
-    };
-
-    const handleEditSaved = (): void => {
-        setEditingConnection(null);
-        void getConnections();
-    };
 
     const handleDump = async (id: string): Promise<void> => {
         setDumpingIds((prev) => new Set(prev).add(id));
@@ -110,7 +99,6 @@ export default function DatabasesPage(): React.JSX.Element {
             <ConnectionCardList
                 databases={connections.map(mapToDatabase)}
                 isLoading={isPending && connections.length === 0}
-                onEdit={handleEdit}
                 onDump={handleDump}
                 onRebuild={handleRebuild}
                 onGenerateData={(id) => setDataGenConnectionId(id)}
@@ -118,11 +106,6 @@ export default function DatabasesPage(): React.JSX.Element {
                 rebuildingIds={rebuildingIds}
             />
             <AddConnectionForm onSaved={() => void getConnections()} />
-            <EditConnectionModal
-                connection={editingConnection}
-                onClose={() => setEditingConnection(null)}
-                onSaved={handleEditSaved}
-            />
             <DataGeneratorDrawer
                 connectionId={dataGenConnectionId}
                 connectionName={connections.find((c) => c.id === dataGenConnectionId)?.name ?? ""}

--- a/Frontend/src/app/dashboard/history/page.tsx
+++ b/Frontend/src/app/dashboard/history/page.tsx
@@ -173,7 +173,6 @@ export default function HistoryPage(): React.JSX.Element {
                         description={
                             <>
                                 <p>This will execute the rollback SQL on the live database.</p>
-                                <p>Ensure you have a backup before proceeding.</p>
                             </>
                         }
                         onConfirm={() => void handleRollback(record.id)}

--- a/Frontend/src/app/login/LoginFooter.tsx
+++ b/Frontend/src/app/login/LoginFooter.tsx
@@ -1,16 +1,17 @@
 "use client";
 
+import Link from "next/link";
 import React from "react";
 import { useStyles } from "./style/styles";
 
-/** "Don't have an account?" prompt with request access link. */
+/** "Don't have an account?" prompt linking to the sign-up page. */
 const LoginFooter: React.FC = () => {
     const { styles } = useStyles();
 
     return (
         <p className={styles.footer}>
             {"Don't have an account? "}
-            <span className={styles.footerLink}>Request access</span>
+            <Link href="/signup" className={styles.footerLink}>Sign up</Link>
         </p>
     );
 };

--- a/Frontend/src/app/login/LoginForm.tsx
+++ b/Frontend/src/app/login/LoginForm.tsx
@@ -51,16 +51,16 @@ const LoginForm: React.FC = () => {
                 requiredMark={false}
             >
                 <Form.Item
-                    label="Email Address"
+                    label="Username"
                     name="userNameOrEmailAddress"
                     rules={[
-                        { required: true, message: "Please enter your email address." },
+                        { required: true, message: "Please enter your username." },
                     ]}
                 >
                     <Input
-                        placeholder="engineer@company.com"
+                        placeholder="your username"
                         size="large"
-                        autoComplete="email"
+                        autoComplete="username"
                     />
                 </Form.Item>
 

--- a/Frontend/src/app/login/page.tsx
+++ b/Frontend/src/app/login/page.tsx
@@ -1,17 +1,15 @@
 import LoginHeader from "./LoginHeader";
 import LoginForm from "./LoginForm";
-import LoginSocialButtons from "./LoginSocialButtons";
 import LoginFooter from "./LoginFooter";
 import LoginPageWrapper from "./LoginPageWrapper";
 
-/** Login page — composes header, form, social buttons, and footer. */
+/** Login page — composes header, form, and footer. */
 export default function LoginPage(): React.JSX.Element {
     return (
         <LoginPageWrapper>
             <LoginHeader />
             <div>
                 <LoginForm />
-                <LoginSocialButtons />
             </div>
             <LoginFooter />
         </LoginPageWrapper>

--- a/Frontend/src/app/signup/SignUpForm.tsx
+++ b/Frontend/src/app/signup/SignUpForm.tsx
@@ -1,0 +1,124 @@
+"use client";
+
+import { Button, Form, Input, message } from "antd";
+import { useRouter } from "next/navigation";
+import React, { useState } from "react";
+import { API_CONSTANTS } from "@/constants/ApiConstants";
+import { useStyles } from "../login/style/styles";
+
+interface ISignUpFormValues {
+    name: string;
+    surname: string;
+    userName: string;
+    emailAddress: string;
+    password: string;
+}
+
+/** Registration form that calls the ABP Account/Register endpoint. */
+const SignUpForm: React.FC = () => {
+    const { styles } = useStyles();
+    const router = useRouter();
+    const [isLoading, setIsLoading] = useState<boolean>(false);
+    const [messageApi, contextHolder] = message.useMessage();
+
+    const handleSubmit = async (values: ISignUpFormValues): Promise<void> => {
+        setIsLoading(true);
+        try {
+            const response = await fetch(API_CONSTANTS.REGISTER, {
+                method: "POST",
+                headers: { "Content-Type": "application/json" },
+                body: JSON.stringify({
+                    name: values.name,
+                    surname: values.surname,
+                    userName: values.userName,
+                    emailAddress: values.emailAddress,
+                    password: values.password,
+                }),
+            });
+
+            const json = await response.json();
+
+            if (json.success) {
+                messageApi.success("Account created! Please sign in.");
+                setTimeout(() => router.push("/login"), 1500);
+            } else {
+                const errorMessage = json.error?.details ?? json.error?.message ?? "Registration failed.";
+                messageApi.error(errorMessage);
+            }
+        } catch {
+            messageApi.error("Unable to reach the server.");
+        } finally {
+            setIsLoading(false);
+        }
+    };
+
+    return (
+        <>
+            {contextHolder}
+            <Form
+                layout="vertical"
+                onFinish={handleSubmit}
+                className={styles.form}
+                requiredMark={false}
+            >
+                <Form.Item
+                    label="First Name"
+                    name="name"
+                    rules={[{ required: true, message: "Please enter your first name." }]}
+                >
+                    <Input placeholder="Jane" size="large" autoComplete="given-name" />
+                </Form.Item>
+
+                <Form.Item
+                    label="Last Name"
+                    name="surname"
+                    rules={[{ required: true, message: "Please enter your last name." }]}
+                >
+                    <Input placeholder="Doe" size="large" autoComplete="family-name" />
+                </Form.Item>
+
+                <Form.Item
+                    label="Username"
+                    name="userName"
+                    rules={[{ required: true, message: "Please choose a username." }]}
+                >
+                    <Input placeholder="janedoe" size="large" autoComplete="username" />
+                </Form.Item>
+
+                <Form.Item
+                    label="Email Address"
+                    name="emailAddress"
+                    rules={[
+                        { required: true, message: "Please enter your email address." },
+                        { type: "email", message: "Please enter a valid email address." },
+                    ]}
+                >
+                    <Input placeholder="jane@company.com" size="large" autoComplete="email" />
+                </Form.Item>
+
+                <Form.Item
+                    label="Password"
+                    name="password"
+                    rules={[
+                        { required: true, message: "Please choose a password." },
+                        { min: 8, message: "Password must be at least 8 characters." },
+                    ]}
+                >
+                    <Input.Password size="large" autoComplete="new-password" />
+                </Form.Item>
+
+                <Button
+                    type="primary"
+                    htmlType="submit"
+                    size="large"
+                    loading={isLoading}
+                    className={styles.submitButton}
+                >
+                    Create Account
+                </Button>
+            </Form>
+        </>
+    );
+};
+
+export default SignUpForm;

--- a/Frontend/src/app/signup/page.tsx
+++ b/Frontend/src/app/signup/page.tsx
@@ -1,0 +1,27 @@
+import React from "react";
+import Link from "next/link";
+import { ThunderboltFilled } from "@ant-design/icons";
+import LoginPageWrapper from "../login/LoginPageWrapper";
+import SignUpForm from "./SignUpForm";
+
+/** Sign-up page — reuses the login layout with a registration form. */
+export default function SignUpPage(): React.JSX.Element {
+    return (
+        <LoginPageWrapper>
+            <div style={{ display: "flex", flexDirection: "column", alignItems: "center", marginBottom: 32, textAlign: "center" }}>
+                <div style={{ width: 56, height: 56, borderRadius: 14, background: "rgba(124,58,237,0.2)", border: "1px solid rgba(124,58,237,0.4)", display: "flex", alignItems: "center", justifyContent: "center", fontSize: 26, color: "#a78bfa", marginBottom: 20 }}>
+                    <ThunderboltFilled />
+                </div>
+                <h1 style={{ fontSize: 26, fontWeight: 700, margin: "0 0 8px", letterSpacing: "-0.3px" }}>Create an account</h1>
+                <p style={{ fontSize: 14, margin: 0, opacity: 0.6 }}>Join SQL Ninja today.</p>
+            </div>
+            <div>
+                <SignUpForm />
+            </div>
+            <p style={{ marginTop: 28, fontSize: 14, textAlign: "center", opacity: 0.7 }}>
+                {"Already have an account? "}
+                <Link href="/login" style={{ color: "#7c3aed" }}>Sign in</Link>
+            </p>
+        </LoginPageWrapper>
+    );
+}

--- a/Frontend/src/constants/ApiConstants.ts
+++ b/Frontend/src/constants/ApiConstants.ts
@@ -6,6 +6,7 @@ const API_BASE_URL: string = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 export const API_CONSTANTS = {
     AUTHENTICATE: `${API_BASE_URL}/api/TokenAuth/Authenticate`,
+    REGISTER: `${API_BASE_URL}/api/services/app/Account/Register`,
     TEST_CONNECTION: `${API_BASE_URL}/api/services/app/databaseConnection/testConnection`,
     SAVE_CONNECTION: `${API_BASE_URL}/api/services/app/databaseConnection/saveConnection`,
     GET_ALL_CONNECTIONS: `${API_BASE_URL}/api/services/app/databaseConnection/getAll`,

--- a/Frontend/tests/signup.spec.ts
+++ b/Frontend/tests/signup.spec.ts
@@ -1,0 +1,18 @@
+import { test, expect } from '@playwright/test';
+
+test.describe('SignUp', () => {
+    test('loads successfully', async ({ page }) => {
+        await page.goto('/signup');
+        await expect(page.getByRole('heading', { name: 'Create an account' })).toBeVisible();
+    });
+
+    test('has correct URL', async ({ page }) => {
+        await page.goto('/signup');
+        await expect(page).toHaveURL('/signup');
+    });
+
+    test('shows link back to login', async ({ page }) => {
+        await page.goto('/signup');
+        await expect(page.getByRole('link', { name: 'Sign in' })).toBeVisible();
+    });
+});


### PR DESCRIPTION
## Summary
- Remove database selector and search from top navigation bar
- Remove Edit button from database connection cards
- Replace Settings with Sign Out in sidebar (clears token and redirects to `/login`)
- Remove GitHub/Google social login buttons from login page
- Change login field label from "Email Address" to "Username"
- Add `/signup` page with full registration form (Name, Surname, Username, Email, Password)
- Add margin-top to Schema Only toggle in Add Connection form
- Hide Avg Improvement dashboard card when value is N/A
- Expand Schema Advisor AI prompt to cover: normalisation/denormalisation, data type optimisation (TEXT→VARCHAR), index removal on write-heavy tables, stored procedures, returning only needed columns, avoiding functions on indexed columns, join optimisation, and materialised views

