### PR TITLE
fix: further UI cleanup — rename status, remove benchmark, simplify history

### DIFF
--- a/Frontend/src/app/dashboard/databases/ConnectionCard/ConnectionCard.tsx
+++ b/Frontend/src/app/dashboard/databases/ConnectionCard/ConnectionCard.tsx
@@ -5,9 +5,6 @@ import { Button, Tag, Tooltip } from "antd";
 import { DatabaseOutlined, CloudDownloadOutlined, ReloadOutlined, ThunderboltOutlined } from "@ant-design/icons";
 import { useStyles } from "../style/styles";
 
-/** Connection status values for a database card. */
-export type TConnectionStatus = "connected" | "disconnected";
-
 /** Shape of a single database connection entry. */
 export interface IDatabase {
     /** Unique identifier for the connection. */
@@ -22,8 +19,6 @@ export interface IDatabase {
     host: string;
     /** Measured round-trip latency, or "-" if unavailable. */
     latency: string;
-    /** Whether the connection is currently active. */
-    status: TConnectionStatus;
     /** Human-readable restore status label. */
     restoreStatus: string;
     /** Whether a local copy of the database is ready to query. */
@@ -75,8 +70,8 @@ const ConnectionCard: React.FC<IConnectionCardProps> = ({ database, onDump, onRe
                 </div>
             </div>
             <div className={styles.cardFooter}>
-                <span className={database.status === "connected" ? styles.badgeConnected : styles.badgeDisconnected}>
-                    {database.status}
+                <span className={styles.badgeConnected}>
+                    Saved
                 </span>
                 <span className={database.isLocalReady ? styles.badgeConnected : styles.badgeDisconnected}>
                     {database.restoreStatus}

--- a/Frontend/src/app/dashboard/databases/page.tsx
+++ b/Frontend/src/app/dashboard/databases/page.tsx
@@ -18,7 +18,6 @@ function mapToDatabase(dto: IDatabaseConnectionDto): IDatabase {
         version: 0,
         host: dto.dbHost,
         latency: "-",
-        status: "connected",
         restoreStatus: RESTORE_STATUS_LABELS[dto.restoreStatus] ?? "Unknown",
         isLocalReady: dto.restoreStatus === 3,
         dumpStatus: dto.dumpStatus,

--- a/Frontend/src/app/dashboard/history/HistoryHeader/HistoryHeader.tsx
+++ b/Frontend/src/app/dashboard/history/HistoryHeader/HistoryHeader.tsx
@@ -1,19 +1,10 @@
 "use client";
 
 import React from "react";
-import { Button } from "antd";
-import { FilterOutlined, DownloadOutlined } from "@ant-design/icons";
 import { useStyles } from "../style/styles";
 
-interface IHistoryHeaderProps {
-    /** Called when the user clicks Filter. */
-    onFilter: () => void;
-    /** Called when the user clicks Export CSV. */
-    onExportCsv: () => void;
-}
-
-/** Page title row with heading, subtitle, and Filter / Export CSV action buttons. */
-const HistoryHeader: React.FC<IHistoryHeaderProps> = ({ onFilter, onExportCsv }) => {
+/** Page title row with heading and subtitle. */
+const HistoryHeader: React.FC = () => {
     const { styles } = useStyles();
 
     return (
@@ -21,10 +12,6 @@ const HistoryHeader: React.FC<IHistoryHeaderProps> = ({ onFilter, onExportCsv })
             <div>
                 <h1 className={styles.pageTitle}>Analysis History</h1>
                 <p className={styles.pageSubtitle}>Log of all queries analysed and optimised across your team.</p>
-            </div>
-            <div className={styles.headerActions}>
-                <Button icon={<FilterOutlined />} onClick={onFilter}>Filter</Button>
-                <Button icon={<DownloadOutlined />} onClick={onExportCsv}>Export CSV</Button>
             </div>
         </div>
     );

--- a/Frontend/src/app/dashboard/history/page.tsx
+++ b/Frontend/src/app/dashboard/history/page.tsx
@@ -1,60 +1,21 @@
 "use client";
 
 import React, { useState, useEffect, useCallback } from "react";
-import { Spin, Tabs, Table, Tag, Button, Popconfirm, Alert, Typography, Modal } from "antd";
+import { Spin, Table, Tag, Button, Popconfirm, Alert, Typography, Modal, Tabs } from "antd";
 import type { TableProps } from "antd";
 import { RollbackOutlined } from "@ant-design/icons";
 import HistoryHeader from "./HistoryHeader/HistoryHeader";
-import HistoryTable from "./HistoryTable/HistoryTable";
-import HistoryPagination from "./HistoryPagination/HistoryPagination";
-import { IQueryHistoryDto } from "@/services/queryHistoryService";
 import { IMigrationHistoryDto, getAllMigrationHistory, rollbackMigration } from "@/services/migrationHistoryService";
-import { useDatabaseConnectionState, useDatabaseConnectionActions } from "@/providers/databaseConnection";
-import { useQueryHistoryState, useQueryHistoryActions } from "@/providers/queryHistory";
 import { useStyles } from "./style/styles";
 
 const { Text } = Typography;
 
-type HistoryStatus = "success" | "warning" | "critical";
-
-interface IHistoryEntry {
-    id: string;
-    queryPreview: string;
-    database: string;
-    improvement: string | null;
-    status: HistoryStatus;
-    date: string;
-}
-
 const PAGE_SIZE = 6;
 
-function toHistoryEntry(dto: IQueryHistoryDto, connectionMap: Map<string, string>): IHistoryEntry {
-    const connectionName = connectionMap.get(dto.databaseConnectionId) ?? dto.databaseConnectionId.slice(0, 8);
-    const status: HistoryStatus = dto.errorMessage ? "critical" : dto.suggestedQuery ? "warning" : "success";
-    const date = new Date(dto.creationTime).toLocaleString([], {
-        year: "numeric", month: "2-digit", day: "2-digit", hour: "2-digit", minute: "2-digit",
-    });
-    return {
-        id: dto.id.slice(0, 8).toUpperCase(),
-        queryPreview: dto.queryText,
-        database: connectionName,
-        improvement: dto.suggestedQuery ? "Has suggestion" : null,
-        status,
-        date,
-    };
-}
-
-/** Analysis History page — paginated log of query executions and applied schema migrations. */
+/** Applied Migrations history page. */
 export default function HistoryPage(): React.JSX.Element {
     const { styles } = useStyles();
-    const { connections } = useDatabaseConnectionState();
-    const { getConnections } = useDatabaseConnectionActions();
-    const { entries, isPending } = useQueryHistoryState();
-    const { getAllHistory } = useQueryHistoryActions();
 
-    const [currentPage, setCurrentPage] = useState<number>(1);
-
-    // Applied Migrations tab state
     const [migrations, setMigrations] = useState<IMigrationHistoryDto[]>([]);
     const [migrationsLoading, setMigrationsLoading] = useState(false);
     const [rollbackError, setRollbackError] = useState<string | null>(null);
@@ -73,20 +34,8 @@ export default function HistoryPage(): React.JSX.Element {
     }, []);
 
     useEffect(() => {
-        void getConnections();
-        void getAllHistory();
         void loadMigrations();
-    }, [getConnections, getAllHistory, loadMigrations]);
-
-    const connectionMap = new Map<string, string>(connections.map((c) => [c.id, c.name]));
-    const mappedEntries = entries.map((dto) => toHistoryEntry(dto, connectionMap));
-
-    const totalEntries = mappedEntries.length;
-    const totalPages = Math.max(1, Math.ceil(totalEntries / PAGE_SIZE));
-    const safePage = Math.min(currentPage, totalPages);
-    const rangeStart = totalEntries === 0 ? 0 : (safePage - 1) * PAGE_SIZE + 1;
-    const rangeEnd = Math.min(safePage * PAGE_SIZE, totalEntries);
-    const pageEntries = mappedEntries.slice(rangeStart - 1, rangeEnd);
+    }, [loadMigrations]);
 
     const handleRollback = async (migrationId: string): Promise<void> => {
         setRollingBackId(migrationId);
@@ -170,11 +119,7 @@ export default function HistoryPage(): React.JSX.Element {
                 record.status === 0 ? (
                     <Popconfirm
                         title="Roll back migration"
-                        description={
-                            <>
-                                <p>This will execute the rollback SQL on the live database.</p>
-                            </>
-                        }
+                        description={<p>This will execute the rollback SQL on the live database.</p>}
                         onConfirm={() => void handleRollback(record.id)}
                         okText="Roll Back"
                         cancelText="Cancel"
@@ -195,36 +140,17 @@ export default function HistoryPage(): React.JSX.Element {
         },
     ];
 
-    const queryHistoryTab = (
+    return (
         <>
-            {isPending && entries.length === 0 ? (
-                <div style={{ display: "flex", justifyContent: "center", paddingTop: 80 }}>
-                    <Spin size="large" />
-                </div>
-            ) : (
-                <>
-                    <HistoryTable entries={pageEntries} />
-                    <HistoryPagination
-                        rangeStart={rangeStart}
-                        rangeEnd={rangeEnd}
-                        totalEntries={totalEntries}
-                        currentPage={safePage}
-                        totalPages={totalPages}
-                        onPageChange={setCurrentPage}
-                    />
-                </>
-            )}
-        </>
-    );
+            <HistoryHeader />
 
-    const migrationsTab = (
-        <>
             {rollbackSuccess && (
                 <Alert type="success" title={rollbackSuccess} closable onClose={() => setRollbackSuccess(null)} style={{ marginBottom: 16 }} />
             )}
             {rollbackError && (
                 <Alert type="error" title={`Rollback failed: ${rollbackError}`} closable onClose={() => setRollbackError(null)} style={{ marginBottom: 16 }} />
             )}
+
             {migrationsLoading ? (
                 <div style={{ display: "flex", justifyContent: "center", paddingTop: 80 }}>
                     <Spin size="large" />
@@ -240,19 +166,6 @@ export default function HistoryPage(): React.JSX.Element {
                     />
                 </div>
             )}
-        </>
-    );
-
-    return (
-        <>
-            <HistoryHeader onFilter={() => {}} onExportCsv={() => {}} />
-            <Tabs
-                defaultActiveKey="queries"
-                items={[
-                    { key: "queries", label: "Query History", children: queryHistoryTab },
-                    { key: "migrations", label: "Applied Migrations", children: migrationsTab },
-                ]}
-            />
 
             <Modal
                 title="Migration SQL"

--- a/Frontend/src/app/dashboard/schema-advisor/RefactoringPanel/RefactoringPanel.tsx
+++ b/Frontend/src/app/dashboard/schema-advisor/RefactoringPanel/RefactoringPanel.tsx
@@ -2,7 +2,7 @@
 
 import React from "react";
 import { Button } from "antd";
-import { ArrowRightOutlined, TableOutlined, ThunderboltOutlined, ExperimentOutlined } from "@ant-design/icons";
+import { ArrowRightOutlined, TableOutlined, ExperimentOutlined } from "@ant-design/icons";
 import { useStyles } from "../style/styles";
 
 /** A single column in a schema table. */
@@ -52,8 +52,6 @@ interface IRefactoringPanelProps {
     detail: IRefactoringDetail;
     /** Called when the user clicks Generate Migration. */
     onGenerateMigration: () => void;
-    /** Called when the user clicks Benchmark Query. */
-    onBenchmark: () => void;
     /** Called when the user clicks Compare Schemas. */
     onCompare: () => void;
 }
@@ -84,7 +82,7 @@ const SchemaTableBox: React.FC<{ table: ISchemaTableDef; styles: Record<string, 
 };
 
 /** Right panel showing the schema diff diagram and impact metrics for the selected recommendation. */
-const RefactoringPanel: React.FC<IRefactoringPanelProps> = ({ detail, onGenerateMigration, onBenchmark, onCompare }) => {
+const RefactoringPanel: React.FC<IRefactoringPanelProps> = ({ detail, onGenerateMigration, onCompare }) => {
     const { styles } = useStyles();
 
     return (
@@ -92,7 +90,6 @@ const RefactoringPanel: React.FC<IRefactoringPanelProps> = ({ detail, onGenerate
             <div className={styles.detailHeader}>
                 <h2 className={styles.detailTitle}>{detail.title}</h2>
                 <div style={{ display: "flex", gap: 8 }}>
-                    <Button icon={<ThunderboltOutlined />} onClick={onBenchmark}>Benchmark Query</Button>
                     <Button icon={<ExperimentOutlined />} onClick={onCompare}>Compare Schemas</Button>
                     <Button type="primary" onClick={onGenerateMigration}>Generate Migration</Button>
                 </div>

--- a/Frontend/src/app/dashboard/schema-advisor/page.tsx
+++ b/Frontend/src/app/dashboard/schema-advisor/page.tsx
@@ -1,9 +1,8 @@
 "use client";
 
 import React, { useState, useEffect } from "react";
-import { Button, Select, Alert, Modal, Spin, Empty, Typography, Input, Table, Slider, Tag, Divider, Tooltip, Tabs, Popconfirm } from "antd";
-import type { TableProps } from "antd";
-import { ScanOutlined, CopyOutlined, ThunderboltOutlined, ExperimentOutlined, PlusOutlined, DeleteOutlined, HistoryOutlined, ClockCircleOutlined } from "@ant-design/icons";
+import { Button, Select, Alert, Modal, Spin, Empty, Typography, Input, Slider, Tag, Divider, Tooltip, Tabs, Popconfirm } from "antd";
+import { ScanOutlined, CopyOutlined, ExperimentOutlined, PlusOutlined, DeleteOutlined, HistoryOutlined, ClockCircleOutlined } from "@ant-design/icons";
 import RecommendationList from "./RecommendationList/RecommendationList";
 import RefactoringPanel from "./RefactoringPanel/RefactoringPanel";
 import { useStyles } from "./style/styles";
@@ -18,7 +17,6 @@ import {
     IBenchmarkQueryPair,
 } from "@/services/schemaAdvisorService";
 import { ISchemaAdvisorScanDto } from "@/services/schemaAdvisorHistoryService";
-import { executeQuery } from "@/services/queryService";
 import { useDatabaseConnectionState, useDatabaseConnectionActions } from "@/providers/databaseConnection";
 import { useSchemaAdvisorHistoryState, useSchemaAdvisorHistoryActions } from "@/providers/schemaAdvisorHistory";
 
@@ -50,12 +48,6 @@ export default function SchemaAdvisorPage(): React.JSX.Element {
     const [isApplying, setIsApplying] = useState(false);
     const [applyError, setApplyError] = useState<string | null>(null);
     const [applySuccess, setApplySuccess] = useState(false);
-
-    const [isBenchmarkModalOpen, setIsBenchmarkModalOpen] = useState(false);
-    const [benchmarkSql, setBenchmarkSql] = useState("");
-    const [benchmarkRuns, setBenchmarkRuns] = useState<number[]>([]);
-    const [isBenchmarking, setIsBenchmarking] = useState(false);
-    const [benchmarkError, setBenchmarkError] = useState<string | null>(null);
 
     // Compare Schemas modal state
     const [isCompareModalOpen, setIsCompareModalOpen] = useState(false);
@@ -206,16 +198,6 @@ export default function SchemaAdvisorPage(): React.JSX.Element {
         }
     };
 
-    const handleOpenBenchmark = (): void => {
-        if (!selectedRecommendation) return;
-        // Pre-fill with a simple SELECT on the current table, stripping the "(Current)" label suffix
-        const tableName = selectedRecommendation.currentTable.label.replace(/\s*\(.*\)$/, "").trim();
-        setBenchmarkSql(`SELECT * FROM ${tableName} LIMIT 1000;`);
-        setBenchmarkRuns([]);
-        setBenchmarkError(null);
-        setIsBenchmarkModalOpen(true);
-    };
-
     const handleOpenCompare = (): void => {
         if (!selectedConnectionId || !selectedRecommendation) return;
         setCompareStep("setup");
@@ -275,31 +257,6 @@ export default function SchemaAdvisorPage(): React.JSX.Element {
         } catch (err) {
             setCompareError(err instanceof Error ? err.message : "An unexpected error occurred.");
             setCompareStep("setup");
-        }
-    };
-
-    const handleRunBenchmark = async (): Promise<void> => {
-        if (!selectedConnectionId || !benchmarkSql.trim()) return;
-
-        setIsBenchmarking(true);
-        setBenchmarkRuns([]);
-        setBenchmarkError(null);
-
-        try {
-            const times: number[] = [];
-            for (let i = 0; i < 3; i++) {
-                const result = await executeQuery({ connectionId: selectedConnectionId, sql: benchmarkSql });
-                if (result.error) {
-                    setBenchmarkError(result.error);
-                    return;
-                }
-                times.push(result.executionTimeMs);
-                setBenchmarkRuns([...times]);
-            }
-        } catch (err) {
-            setBenchmarkError(err instanceof Error ? err.message : "An unexpected error occurred.");
-        } finally {
-            setIsBenchmarking(false);
         }
     };
 
@@ -386,7 +343,6 @@ export default function SchemaAdvisorPage(): React.JSX.Element {
                     <RefactoringPanel
                         detail={refactoringDetail}
                         onGenerateMigration={() => void handleGenerateMigration()}
-                        onBenchmark={handleOpenBenchmark}
                         onCompare={handleOpenCompare}
                     />
                 </div>
@@ -461,99 +417,6 @@ export default function SchemaAdvisorPage(): React.JSX.Element {
                         ]}
                     />
                 )}
-            </Modal>
-            <Modal
-                title={
-                    <span>
-                        <ThunderboltOutlined style={{ marginRight: 8 }} />
-                        Benchmark Query
-                    </span>
-                }
-                open={isBenchmarkModalOpen}
-                onCancel={() => setIsBenchmarkModalOpen(false)}
-                width={680}
-                footer={[
-                    <Button
-                        key="run"
-                        type="primary"
-                        icon={<ThunderboltOutlined />}
-                        loading={isBenchmarking}
-                        disabled={!benchmarkSql.trim()}
-                        onClick={() => void handleRunBenchmark()}
-                    >
-                        Run Benchmark
-                    </Button>,
-                    <Button key="close" onClick={() => setIsBenchmarkModalOpen(false)}>
-                        Close
-                    </Button>,
-                ]}
-            >
-                <p style={{ marginBottom: 8, fontSize: 13 }}>
-                    Enter a query that exercises the affected table. It will be run <strong>3 times</strong> and the results compared against the AI&#39;s estimated improvement.
-                </p>
-                <Input.TextArea
-                    value={benchmarkSql}
-                    onChange={(e) => setBenchmarkSql(e.target.value)}
-                    rows={4}
-                    style={{ fontFamily: "monospace", fontSize: 13, marginBottom: 16 }}
-                    placeholder="SELECT * FROM table_name WHERE ..."
-                />
-
-                {benchmarkError && (
-                    <Alert type="error" title={benchmarkError} style={{ marginBottom: 16 }} />
-                )}
-
-                {isBenchmarking && benchmarkRuns.length === 0 && (
-                    <div style={{ display: "flex", justifyContent: "center", padding: 24 }}>
-                        <Spin tip="Running benchmark..." />
-                    </div>
-                )}
-
-                {benchmarkRuns.length > 0 && (() => {
-                    const avg = Math.round(benchmarkRuns.reduce((a, b) => a + b, 0) / benchmarkRuns.length);
-                    const tableData = [
-                        ...benchmarkRuns.map((ms, i) => ({ key: i, run: `Run ${i + 1}`, timeMs: ms })),
-                        { key: "avg", run: "Average", timeMs: avg },
-                    ];
-                    const columns: TableProps<typeof tableData[number]>["columns"] = [
-                        { title: "Run", dataIndex: "run", key: "run", width: 100 },
-                        {
-                            title: "Execution Time",
-                            dataIndex: "timeMs",
-                            key: "timeMs",
-                            render: (ms: number, record) => (
-                                <Text strong={record.key === "avg"}>{ms} ms</Text>
-                            ),
-                        },
-                    ];
-
-                    return (
-                        <>
-                            <Table
-                                columns={columns}
-                                dataSource={tableData}
-                                pagination={false}
-                                size="small"
-                                style={{ marginBottom: 16 }}
-                            />
-                            {selectedRecommendation && selectedRecommendation.metrics.length > 0 && (
-                                <Alert
-                                    type="info"
-                                    title="AI Estimated Improvement"
-                                    description={
-                                        <ul style={{ margin: 0, paddingLeft: 18 }}>
-                                            {selectedRecommendation.metrics.map((m) => (
-                                                <li key={m.label}>
-                                                    {m.label}: <strong>{m.before}</strong> → <strong>{m.after}</strong>
-                                                </li>
-                                            ))}
-                                        </ul>
-                                    }
-                                />
-                            )}
-                        </>
-                    );
-                })()}
             </Modal>
             {/* ── SCAN HISTORY ── */}
             {selectedConnectionId && (


### PR DESCRIPTION
## Summary
- Rename "connected" badge to "Saved" on database connection cards
- Remove Benchmark Query button and modal from Schema Advisor
- History page: show Applied Migrations only, remove Query History tab
- History page: remove Filter and Export CSV buttons from header

## Closes
- #116 — Rename 'connected' status badge to 'Saved' on database connection cards
- #117 — Remove Benchmark Query button and modal from Schema Advisor
- #118 — Simplify History page to show Applied Migrations only
