### PR TITLE
feat: Show Last Synced time instead of Host on database cards

### DIFF
--- a/Frontend/src/app/dashboard/databases/ConnectionCard/ConnectionCard.tsx
+++ b/Frontend/src/app/dashboard/databases/ConnectionCard/ConnectionCard.tsx
@@ -31,6 +31,8 @@ export interface IDatabase {
     restoreStatusRaw: number;
     /** Whether this connection was configured to dump schema only (no row data). */
     schemaOnly: boolean;
+    /** Name of the specific database on the host, or null if not set. */
+    databaseName: string | null;
 }
 
 interface IConnectionCardProps {
@@ -62,6 +64,10 @@ const ConnectionCard: React.FC<IConnectionCardProps> = ({ database, onDump, onRe
                 </div>
             </div>
             <div className={styles.cardMeta}>
+                <div className={styles.cardMetaRow}>
+                    <span className={styles.cardMetaLabel}>Database</span>
+                    <span className={styles.cardMetaValue}>{database.databaseName ?? "—"}</span>
+                </div>
                 <div className={styles.cardMetaRow}>
                     <span className={styles.cardMetaLabel}>Last Synced</span>
                     <span className={styles.cardMetaValue}>

--- a/Frontend/src/app/dashboard/databases/page.tsx
+++ b/Frontend/src/app/dashboard/databases/page.tsx
@@ -19,6 +19,7 @@ function mapToDatabase(dto: IDatabaseConnectionDto): IDatabase {
         host: dto.dbHost,
         latency: "-",
         lastSyncTime: dto.lastSyncTime ?? null,
+        databaseName: dto.databaseName ?? null,
         restoreStatus: RESTORE_STATUS_LABELS[dto.restoreStatus] ?? "Unknown",
         isLocalReady: dto.restoreStatus === 3,
         dumpStatus: dto.dumpStatus,


### PR DESCRIPTION
## Summary
- Replace the Host metadata row on connection cards with a Last Synced row
- Displays a locale-formatted timestamp from `lastSyncTime`, or "Never" if null

## Closes
Closes #124
