### PR TITLE
feat: Auth-based route guards and auto-redirect

### DIFF
--- a/Frontend/src/app/login/LoginForm.tsx
+++ b/Frontend/src/app/login/LoginForm.tsx
@@ -2,7 +2,7 @@
 
 import { Button, Checkbox, Form, Input, message } from "antd";
 import { useRouter } from "next/navigation";
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { authenticate } from "@/services/authService";
 import { tokenService } from "@/services/tokenService";
 import { useStyles } from "./style/styles";
@@ -19,6 +19,12 @@ const LoginForm: React.FC = () => {
     const router = useRouter();
     const [isLoading, setIsLoading] = useState<boolean>(false);
     const [messageApi, contextHolder] = message.useMessage();
+
+    useEffect(() => {
+        if (tokenService.isAuthenticated()) {
+            void router.replace("/dashboard");
+        }
+    }, [router]);
 
     const handleSubmit = async (values: ILoginFormValues): Promise<void> => {
         setIsLoading(true);

--- a/Frontend/src/app/page.tsx
+++ b/Frontend/src/app/page.tsx
@@ -2,11 +2,13 @@ import LandingNavbar from "./(landing)/LandingNavbar/LandingNavbar";
 import HeroSection from "./(landing)/HeroSection/HeroSection";
 import DemoSection from "./(landing)/DemoSection/DemoSection";
 import FeaturesSection from "./(landing)/FeaturesSection/FeaturesSection";
+import AuthRedirect from "@/components/AuthRedirect/AuthRedirect";
 
-/** Landing page — composes all landing sections. */
+/** Landing page — composes all landing sections. Redirects to /dashboard if already authenticated. */
 export default function LandingPage(): React.JSX.Element {
     return (
         <>
+            <AuthRedirect />
             <LandingNavbar />
             <main>
                 <HeroSection />

--- a/Frontend/src/components/AuthRedirect/AuthRedirect.tsx
+++ b/Frontend/src/components/AuthRedirect/AuthRedirect.tsx
@@ -1,0 +1,24 @@
+"use client";
+
+import { useEffect } from "react";
+import { useRouter } from "next/navigation";
+import { tokenService } from "@/services/tokenService";
+
+/**
+ * Invisible client component that redirects authenticated users to /dashboard.
+ * Import this into server-rendered pages (e.g. landing, login) that should not
+ * be accessible once the user is logged in.
+ */
+const AuthRedirect: React.FC = () => {
+    const router = useRouter();
+
+    useEffect(() => {
+        if (tokenService.isAuthenticated()) {
+            void router.replace("/dashboard");
+        }
+    }, [router]);
+
+    return null;
+};
+
+export default AuthRedirect;


### PR DESCRIPTION
## Summary
- Adds a reusable `AuthRedirect` client component that redirects authenticated users to `/dashboard`
- Landing page (`/`) now auto-redirects logged-in users to `/dashboard`
- Login page (`/login`) now auto-redirects logged-in users to `/dashboard`

## How it works
`AuthRedirect` reads the token cookie via `tokenService.isAuthenticated()` in a `useEffect` (after hydration, since cookies are client-side only) and calls `router.replace("/dashboard")` if authenticated. The component renders nothing — it is purely a redirect side-effect.
