### PR TITLE
feat: backend sets HttpOnly cookie for JWT token

### DIFF
--- a/Backend/aspnet-core/src/sql_optimizer.Web.Core/Controllers/TokenAuthController.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Web.Core/Controllers/TokenAuthController.cs
@@ -7,6 +7,7 @@ using sql_optimizer.Authorization;
 using sql_optimizer.Authorization.Users;
 using sql_optimizer.Models.TokenAuth;
 using sql_optimizer.MultiTenancy;
+using Microsoft.AspNetCore.Http;
 using Microsoft.AspNetCore.Mvc;
 using System;
 using System.Collections.Generic;
@@ -48,6 +49,8 @@ namespace sql_optimizer.Controllers
 
             var accessToken = CreateAccessToken(CreateJwtClaims(loginResult.Identity));
 
+            AppendAuthCookies(accessToken, loginResult.User.Id);
+
             return new AuthenticateResultModel
             {
                 AccessToken = accessToken,
@@ -55,6 +58,15 @@ namespace sql_optimizer.Controllers
                 ExpireInSeconds = (int)_configuration.Expiration.TotalSeconds,
                 UserId = loginResult.User.Id
             };
+        }
+
+        /// <summary>Clears the auth cookies, effectively logging the user out.</summary>
+        [HttpPost]
+        public IActionResult Logout()
+        {
+            Response.Cookies.Delete("access_token");
+            Response.Cookies.Delete("user_id");
+            return Ok();
         }
 
         private string GetTenancyNameOrNull()
@@ -115,6 +127,38 @@ namespace sql_optimizer.Controllers
         private string GetEncryptedAccessToken(string accessToken)
         {
             return SimpleStringCipher.Instance.Encrypt(accessToken);
+        }
+
+        /// <summary>
+        /// Sets the HttpOnly access_token cookie and a readable user_id cookie on the response.
+        /// The access_token is HttpOnly so JS cannot read it; user_id is readable so the
+        /// frontend can detect authenticated state without exposing the token itself.
+        /// </summary>
+        private void AppendAuthCookies(string accessToken, long userId)
+        {
+            var expiry = DateTimeOffset.UtcNow.Add(_configuration.Expiration);
+            var isHttps = Request.IsHttps;
+
+            var tokenCookieOptions = new CookieOptions
+            {
+                HttpOnly = true,
+                SameSite = SameSiteMode.Lax,
+                Secure = isHttps,
+                Expires = expiry,
+                Path = "/",
+            };
+
+            var userIdCookieOptions = new CookieOptions
+            {
+                HttpOnly = false,
+                SameSite = SameSiteMode.Lax,
+                Secure = isHttps,
+                Expires = expiry,
+                Path = "/",
+            };
+
+            Response.Cookies.Append("access_token", accessToken, tokenCookieOptions);
+            Response.Cookies.Append("user_id", userId.ToString(), userIdCookieOptions);
         }
     }
 }

--- a/Backend/aspnet-core/src/sql_optimizer.Web.Host/Startup/AuthConfigurer.cs
+++ b/Backend/aspnet-core/src/sql_optimizer.Web.Host/Startup/AuthConfigurer.cs
@@ -47,32 +47,39 @@ namespace sql_optimizer.Web.Host.Startup
 
                     options.Events = new JwtBearerEvents
                     {
-                        OnMessageReceived = QueryStringTokenResolver
+                        OnMessageReceived = TokenResolver
                     };
                 });
             }
         }
 
-        /* This method is needed to authorize SignalR javascript client.
-         * SignalR can not send authorization header. So, we are getting it from query string as an encrypted text. */
-        private static Task QueryStringTokenResolver(MessageReceivedContext context)
+        /// <summary>
+        /// Resolves the JWT from either the request cookie (all clients) or the SignalR
+        /// encrypted query-string token (SignalR clients that cannot send headers).
+        /// Cookie-based auth takes priority; the Authorization header is still honoured
+        /// automatically by the JwtBearer middleware when neither source provides a token.
+        /// </summary>
+        private static Task TokenResolver(MessageReceivedContext context)
         {
-            if (!context.HttpContext.Request.Path.HasValue ||
-                !context.HttpContext.Request.Path.Value.StartsWith("/signalr"))
+            // SignalR clients pass the token as an encrypted query-string value.
+            if (context.HttpContext.Request.Path.HasValue &&
+                context.HttpContext.Request.Path.Value.StartsWith("/signalr"))
             {
-                // We are just looking for signalr clients
-                return Task.CompletedTask;
+                var qsAuthToken = context.HttpContext.Request.Query["enc_auth_token"].FirstOrDefault();
+                if (!string.IsNullOrEmpty(qsAuthToken))
+                {
+                    context.Token = SimpleStringCipher.Instance.Decrypt(qsAuthToken);
+                    return Task.CompletedTask;
+                }
             }
 
-            var qsAuthToken = context.HttpContext.Request.Query["enc_auth_token"].FirstOrDefault();
-            if (qsAuthToken == null)
+            // All other clients: read the HttpOnly cookie set by the Authenticate endpoint.
+            var cookieToken = context.HttpContext.Request.Cookies["access_token"];
+            if (!string.IsNullOrEmpty(cookieToken))
             {
-                // Cookie value does not matches to querystring value
-                return Task.CompletedTask;
+                context.Token = cookieToken;
             }
 
-            // Set auth token from cookie
-            context.Token = SimpleStringCipher.Instance.Decrypt(qsAuthToken);
             return Task.CompletedTask;
         }
     }

--- a/Frontend/src/app/dashboard/DashboardSidebar/DashboardSidebar.tsx
+++ b/Frontend/src/app/dashboard/DashboardSidebar/DashboardSidebar.tsx
@@ -15,6 +15,7 @@ import { usePathname, useRouter } from "next/navigation";
 import Link from "next/link";
 import React from "react";
 import { useStyles } from "./style/styles";
+import { logout } from "@/services/authService";
 import { tokenService } from "@/services/tokenService";
 
 const NAV_ITEMS = [
@@ -38,8 +39,10 @@ const DashboardSidebar: React.FC<IDashboardSidebarProps> = ({ onNavClick }) => {
     const router = useRouter();
 
     const handleSignOut = (): void => {
-        tokenService.clear();
-        router.push("/login");
+        void logout().finally(() => {
+            tokenService.clear();
+            router.push("/login");
+        });
     };
 
     const SIGN_OUT_ITEMS = [

--- a/Frontend/src/app/dashboard/databases/AddConnectionForm/AddConnectionForm.tsx
+++ b/Frontend/src/app/dashboard/databases/AddConnectionForm/AddConnectionForm.tsx
@@ -5,7 +5,7 @@ import { Button, Collapse, Input, Select, Switch, notification } from "antd";
 import { DatabaseOutlined, KeyOutlined, CodeOutlined, PlusOutlined } from "@ant-design/icons";
 import { testConnection, DATABASE_TYPE_MAP } from "@/services/databaseConnectionService";
 import { API_CONSTANTS } from "@/constants/ApiConstants";
-import { tokenService } from "@/services/tokenService";
+import { apiFetch } from "@/utils/apiFetch";
 import { useStyles } from "../style/styles";
 
 const ENGINE_OPTIONS = [
@@ -105,12 +105,9 @@ const AddConnectionForm: React.FC<IAddConnectionFormProps> = ({ onSaved }) => {
 
         setIsSaving(true);
         try {
-            const response = await fetch(API_CONSTANTS.SAVE_CONNECTION, {
+            const response = await apiFetch(API_CONSTANTS.SAVE_CONNECTION, {
                 method: "POST",
-                headers: {
-                    "Content-Type": "application/json",
-                    "Authorization": `Bearer ${tokenService.getToken()}`,
-                },
+                headers: { "Content-Type": "application/json" },
                 body: JSON.stringify({
                     name: values.name,
                     dbHost: values.host,

--- a/Frontend/src/app/login/LoginForm.tsx
+++ b/Frontend/src/app/login/LoginForm.tsx
@@ -4,7 +4,6 @@ import { Button, Checkbox, Form, Input, message } from "antd";
 import { useRouter } from "next/navigation";
 import React, { useState } from "react";
 import { authenticate } from "@/services/authService";
-import { tokenService } from "@/services/tokenService";
 import { useStyles } from "./style/styles";
 
 interface ILoginFormValues {
@@ -23,14 +22,11 @@ const LoginForm: React.FC = () => {
     const handleSubmit = async (values: ILoginFormValues): Promise<void> => {
         setIsLoading(true);
         try {
-            const result = await authenticate({
+            await authenticate({
                 userNameOrEmailAddress: values.userNameOrEmailAddress,
                 password: values.password,
                 rememberClient: values.rememberMe ?? false,
             });
-
-            tokenService.setToken(result.accessToken);
-            tokenService.setUserId(result.userId);
 
             router.push("/dashboard");
         } catch (error) {

--- a/Frontend/src/constants/ApiConstants.ts
+++ b/Frontend/src/constants/ApiConstants.ts
@@ -6,6 +6,7 @@ const API_BASE_URL: string = process.env.NEXT_PUBLIC_API_URL ?? "";
 
 export const API_CONSTANTS = {
     AUTHENTICATE: `${API_BASE_URL}/api/TokenAuth/Authenticate`,
+    LOGOUT: `${API_BASE_URL}/api/TokenAuth/Logout`,
     REGISTER: `${API_BASE_URL}/api/services/app/Account/Register`,
     TEST_CONNECTION: `${API_BASE_URL}/api/services/app/databaseConnection/testConnection`,
     SAVE_CONNECTION: `${API_BASE_URL}/api/services/app/databaseConnection/saveConnection`,

--- a/Frontend/src/services/authService.ts
+++ b/Frontend/src/services/authService.ts
@@ -25,11 +25,15 @@ interface IAbpResponse<T> {
     error: IAbpError | null;
 }
 
-/** Authenticates a user against the ABP TokenAuth endpoint and returns the JWT result. */
+/**
+ * Authenticates a user against the ABP TokenAuth endpoint.
+ * The backend sets an HttpOnly access_token cookie and a readable user_id cookie on success.
+ */
 export async function authenticate(request: IAuthenticateRequest): Promise<IAuthenticateResponse> {
     const response = await fetch(API_CONSTANTS.AUTHENTICATE, {
         method: "POST",
         headers: { "Content-Type": "application/json" },
+        credentials: "include",
         body: JSON.stringify(request),
     });
 
@@ -40,4 +44,12 @@ export async function authenticate(request: IAuthenticateRequest): Promise<IAuth
     }
 
     return data.result;
+}
+
+/** Calls the backend logout endpoint, which clears the auth cookies server-side. */
+export async function logout(): Promise<void> {
+    await fetch(API_CONSTANTS.LOGOUT, {
+        method: "POST",
+        credentials: "include",
+    });
 }

--- a/Frontend/src/services/dashboardService.ts
+++ b/Frontend/src/services/dashboardService.ts
@@ -1,5 +1,5 @@
 import { API_CONSTANTS } from "@/constants/ApiConstants";
-import { tokenService } from "./tokenService";
+import { apiFetch } from "@/utils/apiFetch";
 
 /** A single recent query entry for the activity feed and recent analyses table. */
 export interface IRecentActivityItemDto {
@@ -22,11 +22,7 @@ export interface IDashboardStatsDto {
 
 /** Fetches aggregated dashboard statistics for the current tenant. */
 export async function getDashboardStats(): Promise<IDashboardStatsDto> {
-    const response = await fetch(API_CONSTANTS.GET_DASHBOARD_STATS, {
-        headers: {
-            "Authorization": `Bearer ${tokenService.getToken()}`,
-        },
-    });
+    const response = await apiFetch(API_CONSTANTS.GET_DASHBOARD_STATS);
     const json = await response.json();
     return json.result as IDashboardStatsDto;
 }

--- a/Frontend/src/services/databaseConnectionService.ts
+++ b/Frontend/src/services/databaseConnectionService.ts
@@ -1,5 +1,5 @@
 import { API_CONSTANTS } from "@/constants/ApiConstants";
-import { tokenService } from "./tokenService";
+import { apiFetch } from "@/utils/apiFetch";
 
 /** Maps backend DatabaseType enum index to a display name. */
 export const DATABASE_ENGINE_NAMES: Record<number, string> = {
@@ -70,12 +70,7 @@ export interface IDatabaseConnectionDto {
 
 /** Fetches all saved database connections for the current tenant. */
 export async function getDatabaseConnections(): Promise<IDatabaseConnectionDto[]> {
-    const response = await fetch(API_CONSTANTS.GET_ALL_CONNECTIONS, {
-        headers: {
-            "Authorization": `Bearer ${tokenService.getToken()}`,
-        },
-    });
-
+    const response = await apiFetch(API_CONSTANTS.GET_ALL_CONNECTIONS);
     const json = await response.json();
     return (json.result?.items ?? []) as IDatabaseConnectionDto[];
 }
@@ -88,12 +83,9 @@ export interface IUpdateConnectionSettingsRequest {
 
 /** Updates the DatabaseName and SchemaOnly settings of an existing connection. */
 export async function updateConnectionSettings(request: IUpdateConnectionSettingsRequest): Promise<void> {
-    const response = await fetch(API_CONSTANTS.UPDATE_CONNECTION_SETTINGS, {
+    const response = await apiFetch(API_CONSTANTS.UPDATE_CONNECTION_SETTINGS, {
         method: "PUT",
-        headers: {
-            "Content-Type": "application/json",
-            "Authorization": `Bearer ${tokenService.getToken()}`,
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(request),
     });
 
@@ -105,11 +97,8 @@ export async function updateConnectionSettings(request: IUpdateConnectionSetting
 
 /** Manually triggers a fresh database dump for an existing connection. */
 export async function triggerDump(connectionId: string): Promise<void> {
-    const response = await fetch(`${API_CONSTANTS.TRIGGER_DUMP}?connectionId=${connectionId}`, {
+    const response = await apiFetch(`${API_CONSTANTS.TRIGGER_DUMP}?connectionId=${connectionId}`, {
         method: "POST",
-        headers: {
-            "Authorization": `Bearer ${tokenService.getToken()}`,
-        },
     });
 
     if (!response.ok) {
@@ -120,11 +109,8 @@ export async function triggerDump(connectionId: string): Promise<void> {
 
 /** Manually triggers a restore of the latest dump into the local server database. */
 export async function triggerRestore(connectionId: string): Promise<void> {
-    const response = await fetch(`${API_CONSTANTS.TRIGGER_RESTORE}?connectionId=${connectionId}`, {
+    const response = await apiFetch(`${API_CONSTANTS.TRIGGER_RESTORE}?connectionId=${connectionId}`, {
         method: "POST",
-        headers: {
-            "Authorization": `Bearer ${tokenService.getToken()}`,
-        },
     });
 
     if (!response.ok) {
@@ -135,12 +121,9 @@ export async function triggerRestore(connectionId: string): Promise<void> {
 
 /** Calls the backend test-connection endpoint and returns the result. */
 export async function testConnection(request: ITestConnectionRequest): Promise<ITestConnectionResponse> {
-    const response = await fetch(API_CONSTANTS.TEST_CONNECTION, {
+    const response = await apiFetch(API_CONSTANTS.TEST_CONNECTION, {
         method: "POST",
-        headers: {
-            "Content-Type": "application/json",
-            "Authorization": `Bearer ${tokenService.getToken()}`,
-        },
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(request),
     });
 

--- a/Frontend/src/services/migrationHistoryService.ts
+++ b/Frontend/src/services/migrationHistoryService.ts
@@ -1,5 +1,5 @@
 import { API_CONSTANTS } from "@/constants/ApiConstants";
-import { tokenService } from "./tokenService";
+import { apiFetch } from "@/utils/apiFetch";
 
 export type MigrationStatus = "Applied" | "RolledBack";
 
@@ -20,11 +20,8 @@ export interface IRollbackMigrationOutput {
     error: string | null;
 }
 
-function authHeaders(): HeadersInit {
-    return {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${tokenService.getToken()}`,
-    };
+function jsonHeaders(): HeadersInit {
+    return { "Content-Type": "application/json" };
 }
 
 async function safeJson(response: Response): Promise<Record<string, unknown> | null> {
@@ -38,19 +35,16 @@ async function safeJson(response: Response): Promise<Record<string, unknown> | n
 }
 
 export async function getAllMigrationHistory(): Promise<IMigrationHistoryDto[]> {
-    const response = await fetch(API_CONSTANTS.GET_MIGRATION_HISTORY, {
-        method: "GET",
-        headers: authHeaders(),
-    });
+    const response = await apiFetch(API_CONSTANTS.GET_MIGRATION_HISTORY);
     const json = await safeJson(response);
     if (!response.ok) return [];
     return (json?.result as IMigrationHistoryDto[]) ?? [];
 }
 
 export async function rollbackMigration(migrationHistoryId: string): Promise<IRollbackMigrationOutput> {
-    const response = await fetch(API_CONSTANTS.ROLLBACK_MIGRATION, {
+    const response = await apiFetch(API_CONSTANTS.ROLLBACK_MIGRATION, {
         method: "POST",
-        headers: authHeaders(),
+        headers: jsonHeaders(),
         body: JSON.stringify({ migrationHistoryId }),
     });
     const json = await safeJson(response);

--- a/Frontend/src/services/queryHistoryService.ts
+++ b/Frontend/src/services/queryHistoryService.ts
@@ -1,5 +1,5 @@
 import { API_CONSTANTS } from "@/constants/ApiConstants";
-import { tokenService } from "./tokenService";
+import { apiFetch } from "@/utils/apiFetch";
 
 export interface IQueryHistoryDto {
     id: string;
@@ -21,19 +21,9 @@ export interface IAddQueryHistoryRequest {
     executionTime: string;
 }
 
-function authHeaders(): HeadersInit {
-    return {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${tokenService.getToken()}`,
-    };
-}
-
 /** Fetches all query history across every connection, ordered newest-first. */
 export async function getAllQueryHistory(): Promise<IQueryHistoryDto[]> {
-    const response = await fetch(API_CONSTANTS.GET_ALL_QUERY_HISTORY, {
-        method: "GET",
-        headers: authHeaders(),
-    });
+    const response = await apiFetch(API_CONSTANTS.GET_ALL_QUERY_HISTORY);
     const json = await response.json();
     return (json.result ?? []) as IQueryHistoryDto[];
 }
@@ -41,16 +31,16 @@ export async function getAllQueryHistory(): Promise<IQueryHistoryDto[]> {
 /** Fetches query history for a given connection, ordered newest-first. */
 export async function getQueryHistory(connectionId: string): Promise<IQueryHistoryDto[]> {
     const url = `${API_CONSTANTS.GET_QUERY_HISTORY}?connectionId=${encodeURIComponent(connectionId)}`;
-    const response = await fetch(url, { method: "GET", headers: authHeaders() });
+    const response = await apiFetch(url);
     const json = await response.json();
     return (json.result ?? []) as IQueryHistoryDto[];
 }
 
 /** Saves a new query history entry. */
 export async function addQueryHistory(entry: IAddQueryHistoryRequest): Promise<void> {
-    await fetch(API_CONSTANTS.ADD_QUERY_HISTORY, {
+    await apiFetch(API_CONSTANTS.ADD_QUERY_HISTORY, {
         method: "POST",
-        headers: authHeaders(),
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify(entry),
     });
 }
@@ -58,5 +48,5 @@ export async function addQueryHistory(entry: IAddQueryHistoryRequest): Promise<v
 /** Deletes a single query history entry by ID. */
 export async function deleteQueryHistory(entryId: string): Promise<void> {
     const url = `${API_CONSTANTS.DELETE_QUERY_HISTORY}?entryId=${encodeURIComponent(entryId)}`;
-    await fetch(url, { method: "DELETE", headers: authHeaders() });
+    await apiFetch(url, { method: "DELETE" });
 }

--- a/Frontend/src/services/queryService.ts
+++ b/Frontend/src/services/queryService.ts
@@ -1,5 +1,5 @@
 import { API_CONSTANTS } from "@/constants/ApiConstants";
-import { tokenService } from "./tokenService";
+import { apiFetch } from "@/utils/apiFetch";
 
 export interface IExecuteQueryRequest {
     connectionId: string;
@@ -19,18 +19,15 @@ export interface ISchemaTable {
     columns: string[];
 }
 
-function authHeaders(): HeadersInit {
-    return {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${tokenService.getToken()}`,
-    };
+function jsonHeaders(): HeadersInit {
+    return { "Content-Type": "application/json" };
 }
 
 /** Executes a SQL query against the local copy of the given connection's database. */
 export async function executeQuery(request: IExecuteQueryRequest): Promise<IExecuteQueryResponse> {
-    const response = await fetch(API_CONSTANTS.EXECUTE_QUERY, {
+    const response = await apiFetch(API_CONSTANTS.EXECUTE_QUERY, {
         method: "POST",
-        headers: authHeaders(),
+        headers: jsonHeaders(),
         body: JSON.stringify(request),
     });
 
@@ -47,9 +44,9 @@ export interface IAnalyseQueryResponse {
 
 /** Runs EXPLAIN ANALYZE and asks the AI to suggest an optimised version of the query. */
 export async function analyseQuery(request: IExecuteQueryRequest & { intent?: string }): Promise<IAnalyseQueryResponse> {
-    const response = await fetch(API_CONSTANTS.ANALYSE_QUERY, {
+    const response = await apiFetch(API_CONSTANTS.ANALYSE_QUERY, {
         method: "POST",
-        headers: authHeaders(),
+        headers: jsonHeaders(),
         body: JSON.stringify(request),
     });
 
@@ -74,9 +71,9 @@ export interface IBenchmarkResponse {
 
 /** Runs both the original and AI-suggested queries N times each and returns averaged timings. */
 export async function benchmarkQuery(request: IBenchmarkRequest): Promise<IBenchmarkResponse> {
-    const response = await fetch(API_CONSTANTS.BENCHMARK_QUERY, {
+    const response = await apiFetch(API_CONSTANTS.BENCHMARK_QUERY, {
         method: "POST",
-        headers: authHeaders(),
+        headers: jsonHeaders(),
         body: JSON.stringify(request),
     });
 
@@ -130,7 +127,7 @@ export interface IGenerateTestDataResponse {
 /** Fetches detailed schema (column types, PK/FK info) and FK relationships for a connection. */
 export async function getSchemaWithRelationships(connectionId: string): Promise<ISchemaWithRelationships> {
     const url = `${API_CONSTANTS.GET_SCHEMA_WITH_RELATIONSHIPS}?connectionId=${encodeURIComponent(connectionId)}`;
-    const response = await fetch(url, { headers: authHeaders() });
+    const response = await apiFetch(url);
 
     if (!response.ok) {
         throw new Error(`Schema fetch failed: ${response.status}`);
@@ -142,9 +139,9 @@ export async function getSchemaWithRelationships(connectionId: string): Promise<
 
 /** Generates and inserts AI-produced test data into the local schema-only database. */
 export async function generateTestData(request: IGenerateTestDataRequest): Promise<IGenerateTestDataResponse> {
-    const response = await fetch(API_CONSTANTS.GENERATE_TEST_DATA, {
+    const response = await apiFetch(API_CONSTANTS.GENERATE_TEST_DATA, {
         method: "POST",
-        headers: authHeaders(),
+        headers: jsonHeaders(),
         body: JSON.stringify(request),
     });
 
@@ -155,10 +152,7 @@ export async function generateTestData(request: IGenerateTestDataRequest): Promi
 /** Fetches the schema (tables + columns) for the local copy of the given connection's database. */
 export async function getSchema(connectionId: string): Promise<ISchemaTable[]> {
     const url = `${API_CONSTANTS.GET_SCHEMA}?connectionId=${encodeURIComponent(connectionId)}`;
-    const response = await fetch(url, {
-        method: "GET",
-        headers: authHeaders(),
-    });
+    const response = await apiFetch(url);
 
     if (!response.ok) {
         throw new Error(`Schema fetch failed: ${response.status}`);

--- a/Frontend/src/services/schemaAdvisorHistoryService.ts
+++ b/Frontend/src/services/schemaAdvisorHistoryService.ts
@@ -1,5 +1,5 @@
 import { API_CONSTANTS } from "@/constants/ApiConstants";
-import { tokenService } from "./tokenService";
+import { apiFetch } from "@/utils/apiFetch";
 
 export interface ISchemaAdvisorScanDto {
     id: string;
@@ -10,26 +10,14 @@ export interface ISchemaAdvisorScanDto {
     creationTime: string;
 }
 
-function authHeaders(): HeadersInit {
-    return {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${tokenService.getToken()}`,
-    };
-}
-
 export async function getAllScans(): Promise<ISchemaAdvisorScanDto[]> {
-    const response = await fetch(API_CONSTANTS.GET_ALL_SCHEMA_SCANS, {
-        headers: authHeaders(),
-    });
+    const response = await apiFetch(API_CONSTANTS.GET_ALL_SCHEMA_SCANS);
     const json = await response.json();
     return (json.result ?? []) as ISchemaAdvisorScanDto[];
 }
 
 export async function getScansByConnection(connectionId: string): Promise<ISchemaAdvisorScanDto[]> {
-    const response = await fetch(
-        `${API_CONSTANTS.GET_SCHEMA_SCANS_BY_CONNECTION}?connectionId=${connectionId}`,
-        { headers: authHeaders() },
-    );
+    const response = await apiFetch(`${API_CONSTANTS.GET_SCHEMA_SCANS_BY_CONNECTION}?connectionId=${connectionId}`);
     const json = await response.json();
     return (json.result ?? []) as ISchemaAdvisorScanDto[];
 }
@@ -40,9 +28,9 @@ export async function addScan(
     recommendationsJson: string | null,
     errorMessage: string | null,
 ): Promise<ISchemaAdvisorScanDto> {
-    const response = await fetch(API_CONSTANTS.ADD_SCHEMA_SCAN, {
+    const response = await apiFetch(API_CONSTANTS.ADD_SCHEMA_SCAN, {
         method: "POST",
-        headers: authHeaders(),
+        headers: { "Content-Type": "application/json" },
         body: JSON.stringify({
             databaseConnectionId: connectionId,
             recommendationCount,
@@ -55,8 +43,5 @@ export async function addScan(
 }
 
 export async function deleteScan(scanId: string): Promise<void> {
-    await fetch(`${API_CONSTANTS.DELETE_SCHEMA_SCAN}?scanId=${scanId}`, {
-        method: "DELETE",
-        headers: authHeaders(),
-    });
+    await apiFetch(`${API_CONSTANTS.DELETE_SCHEMA_SCAN}?scanId=${scanId}`, { method: "DELETE" });
 }

--- a/Frontend/src/services/schemaAdvisorService.ts
+++ b/Frontend/src/services/schemaAdvisorService.ts
@@ -1,5 +1,5 @@
 import { API_CONSTANTS } from "@/constants/ApiConstants";
-import { tokenService } from "./tokenService";
+import { apiFetch } from "@/utils/apiFetch";
 
 export interface ISchemaColumnDto {
     name: string;
@@ -81,11 +81,8 @@ export interface IBenchmarkRecommendationOutput {
     error: string | null;
 }
 
-function authHeaders(): HeadersInit {
-    return {
-        "Content-Type": "application/json",
-        "Authorization": `Bearer ${tokenService.getToken()}`,
-    };
+function jsonHeaders(): HeadersInit {
+    return { "Content-Type": "application/json" };
 }
 
 /** Safely reads and parses a response body, returning null if the body is empty or not valid JSON. */
@@ -103,9 +100,9 @@ async function safeJson(response: Response): Promise<Record<string, unknown> | n
 
 /** Scans the schema for the given connection and returns AI recommendations. */
 export async function scanSchema(connectionId: string): Promise<IScanSchemaOutput> {
-    const response = await fetch(API_CONSTANTS.SCAN_SCHEMA, {
+    const response = await apiFetch(API_CONSTANTS.SCAN_SCHEMA, {
         method: "POST",
-        headers: authHeaders(),
+        headers: jsonHeaders(),
         body: JSON.stringify({ connectionId }),
     });
 
@@ -124,9 +121,9 @@ export async function getBenchmarkPlan(
     connectionId: string,
     recommendation: IRecommendationDto,
 ): Promise<IGetBenchmarkPlanOutput> {
-    const response = await fetch(API_CONSTANTS.GET_BENCHMARK_PLAN, {
+    const response = await apiFetch(API_CONSTANTS.GET_BENCHMARK_PLAN, {
         method: "POST",
-        headers: authHeaders(),
+        headers: jsonHeaders(),
         body: JSON.stringify({ connectionId, recommendationJson: JSON.stringify(recommendation) }),
     });
     const json = await safeJson(response);
@@ -145,9 +142,9 @@ export async function benchmarkRecommendation(
     readRatio: number,
     runs = 3,
 ): Promise<IBenchmarkRecommendationOutput> {
-    const response = await fetch(API_CONSTANTS.BENCHMARK_RECOMMENDATION, {
+    const response = await apiFetch(API_CONSTANTS.BENCHMARK_RECOMMENDATION, {
         method: "POST",
-        headers: authHeaders(),
+        headers: jsonHeaders(),
         body: JSON.stringify({ connectionId, benchmarkDdl, queryPairs, readRatio, runs }),
     });
     const json = await safeJson(response);
@@ -165,9 +162,9 @@ export async function applyMigration(
     rollbackSql: string | null,
     recommendationTitle: string,
 ): Promise<IApplyMigrationOutput> {
-    const response = await fetch(API_CONSTANTS.APPLY_MIGRATION, {
+    const response = await apiFetch(API_CONSTANTS.APPLY_MIGRATION, {
         method: "POST",
-        headers: authHeaders(),
+        headers: jsonHeaders(),
         body: JSON.stringify({ connectionId, migrationSql, rollbackSql, recommendationTitle }),
     });
     const json = await safeJson(response);
@@ -180,9 +177,9 @@ export async function applyMigration(
 
 /** Generates a PostgreSQL migration script and an EF Core migration class for the supplied recommendation. */
 export async function generateMigration(connectionId: string, recommendation: IRecommendationDto): Promise<IGenerateMigrationOutput> {
-    const response = await fetch(API_CONSTANTS.GENERATE_MIGRATION, {
+    const response = await apiFetch(API_CONSTANTS.GENERATE_MIGRATION, {
         method: "POST",
-        headers: authHeaders(),
+        headers: jsonHeaders(),
         body: JSON.stringify({
             connectionId,
             recommendationJson: JSON.stringify(recommendation),

--- a/Frontend/src/services/tokenService.ts
+++ b/Frontend/src/services/tokenService.ts
@@ -1,12 +1,4 @@
-const TOKEN_KEY = "access_token";
 const USER_ID_KEY = "user_id";
-const COOKIE_MAX_AGE = 60 * 60 * 24 * 7; // 7 days in seconds
-
-function setCookie(name: string, value: string): void {
-    if (typeof document === "undefined") return;
-    const secure = location.protocol === "https:" ? "; Secure" : "";
-    document.cookie = `${name}=${encodeURIComponent(value)}; Max-Age=${COOKIE_MAX_AGE}; Path=/; SameSite=Strict${secure}`;
-}
 
 function getCookie(name: string): string | null {
     if (typeof document === "undefined") return null;
@@ -21,31 +13,25 @@ function deleteCookie(name: string): void {
     document.cookie = `${name}=; Max-Age=0; Path=/`;
 }
 
-/** Manages JWT token persistence in cookies. */
+/**
+ * Provides auth-state helpers for the frontend.
+ * The access token itself is stored in an HttpOnly cookie managed by the backend
+ * and is never readable by JavaScript. The non-HttpOnly user_id cookie is used
+ * solely to detect whether a session is active.
+ */
 export const tokenService = {
-    setToken(token: string): void {
-        setCookie(TOKEN_KEY, token);
-    },
-
-    getToken(): string | null {
-        return getCookie(TOKEN_KEY);
-    },
-
-    setUserId(userId: number): void {
-        setCookie(USER_ID_KEY, String(userId));
-    },
-
     getUserId(): number | null {
         const value = getCookie(USER_ID_KEY);
         return value ? Number(value) : null;
     },
 
+    /** Returns true when the backend-set user_id cookie is present, indicating an active session. */
     isAuthenticated(): boolean {
-        return !!getCookie(TOKEN_KEY);
+        return !!getCookie(USER_ID_KEY);
     },
 
+    /** Clears the readable user_id cookie. Call after the backend logout endpoint clears the HttpOnly token cookie. */
     clear(): void {
-        deleteCookie(TOKEN_KEY);
         deleteCookie(USER_ID_KEY);
     },
 };

--- a/Frontend/src/utils/apiFetch.ts
+++ b/Frontend/src/utils/apiFetch.ts
@@ -1,0 +1,11 @@
+/**
+ * Thin wrapper around fetch that always includes credentials so the browser
+ * sends the HttpOnly auth cookie with every request. All authenticated API
+ * calls must use this instead of calling fetch directly.
+ */
+export async function apiFetch(url: string, options: RequestInit = {}): Promise<Response> {
+    return fetch(url, {
+        ...options,
+        credentials: "include",
+    });
+}


### PR DESCRIPTION
## Summary
- Backend sets an `HttpOnly` `access_token` cookie on login so JS can never read the token
- Backend sets a readable `user_id` cookie so the frontend can detect auth state
- New `Logout` endpoint clears both cookies server-side
- `AuthConfigurer` now reads the JWT from the cookie for all requests (not just SignalR)
- Frontend `apiFetch` utility sends `credentials: include` on every API call
- All service files migrated away from manual `Authorization: Bearer` headers
- `tokenService` simplified — no more `setToken`/`getToken`; `isAuthenticated()` checks `user_id`


Closes #132

