### PR TITLE
fix: add Abp-TenantId header to registration request

### DIFF
--- a/Frontend/src/app/signup/SignUpForm.tsx
+++ b/Frontend/src/app/signup/SignUpForm.tsx
@@ -26,7 +26,7 @@ const SignUpForm: React.FC = () => {
         try {
             const response = await fetch(API_CONSTANTS.REGISTER, {
                 method: "POST",
-                headers: { "Content-Type": "application/json" },
+                headers: { "Content-Type": "application/json", "Abp-TenantId": "1" },
                 body: JSON.stringify({
                     name: values.name,
                     surname: values.surname,


### PR DESCRIPTION
## Summary
- Registration was silently failing with \"Can not register host users!\" because `UserRegistrationManager.CheckForTenant()` requires a tenant in the ABP session
- Added `Abp-TenantId: 1` header to the signup fetch call so ABP resolves the default tenant before the registration handler runs


Closes #135

